### PR TITLE
Using either and svgPicture to specify module icon

### DIFF
--- a/lib/amap/router.dart
+++ b/lib/amap/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/amap/providers/is_amap_admin_provider.dart';
@@ -26,7 +27,7 @@ class AmapRouter {
   static const String addEditProduct = '/add_edit_product';
   static final Module module = Module(
     name: "Amap",
-    icon: HeroIcons.shoppingCart,
+    icon: const Left(HeroIcons.shoppingCart),
     root: AmapRouter.root,
     selected: false,
   );

--- a/lib/booking/router.dart
+++ b/lib/booking/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/booking/providers/is_booking_admin_provider.dart';
@@ -20,7 +21,7 @@ class BookingRouter {
   static const String room = '/room';
   static final Module module = Module(
       name: "Réservation",
-      icon: HeroIcons.tableCells,
+      icon: const Left(HeroIcons.tableCells),
       root: BookingRouter.root,
       selected: false);
   BookingRouter(this.ref);

--- a/lib/cinema/router.dart
+++ b/lib/cinema/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/cinema/providers/is_cinema_admin.dart';
@@ -18,7 +19,7 @@ class CinemaRouter {
   static const String detail = '/detail';
   static final Module module = Module(
       name: "Cinéma",
-      icon: HeroIcons.ticket,
+      icon: const Left(HeroIcons.ticket),
       root: CinemaRouter.root,
       selected: false);
   CinemaRouter(this.ref);

--- a/lib/drawer/class/module.dart
+++ b/lib/drawer/class/module.dart
@@ -1,6 +1,7 @@
 import 'package:either_dart/either.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:heroicons/heroicons.dart';
-
 
 class Module {
   String name;
@@ -20,4 +21,11 @@ class Module {
         root: root ?? this.root,
         selected: selected ?? this.selected,
       );
+
+  Widget getIcon(Color color) {
+    return icon.fold(
+        (heroIcon) => HeroIcon(heroIcon, color: color),
+        (svgPath) => SvgPicture.asset(svgPath,
+            colorFilter: ColorFilter.mode(color, BlendMode.srcIn)));
+  }
 }

--- a/lib/drawer/class/module.dart
+++ b/lib/drawer/class/module.dart
@@ -22,10 +22,13 @@ class Module {
         selected: selected ?? this.selected,
       );
 
-  Widget getIcon(Color color) {
+  Widget getIcon(Color color, {double size = 30}) {
     return icon.fold(
-        (heroIcon) => HeroIcon(heroIcon, color: color),
+        (heroIcon) => HeroIcon(heroIcon, color: color, size: size),
         (svgPath) => SvgPicture.asset(svgPath,
-            colorFilter: ColorFilter.mode(color, BlendMode.srcIn)));
+            width: size,
+            height: size,
+              colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+        ));
   }
 }

--- a/lib/drawer/class/module.dart
+++ b/lib/drawer/class/module.dart
@@ -1,9 +1,10 @@
+import 'package:either_dart/either.dart';
 import 'package:heroicons/heroicons.dart';
 
 
 class Module {
   String name;
-  HeroIcons icon;
+  Either<HeroIcons, String> icon;
   String root;
   bool selected;
 

--- a/lib/drawer/ui/module.dart
+++ b/lib/drawer/ui/module.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:myecl/drawer/class/module.dart';
 import 'package:myecl/drawer/providers/swipe_provider.dart';
@@ -38,20 +36,9 @@ class ModuleUI extends HookConsumerWidget {
                 SizedBox(
                     height: 50,
                     child: Center(
-                        child: m.icon.fold(
-                      (heroIcon) => HeroIcon(
-                        heroIcon,
-                        color: m.root == QR.currentPath
+                        child: m.getIcon(m.root == QR.currentPath
                             ? DrawerColorConstants.selectedText
-                            : DrawerColorConstants.lightText,
-                      ),
-                      (svgPath) => SvgPicture.asset(svgPath,
-                          colorFilter: ColorFilter.mode(
-                              m.root == QR.currentPath
-                                  ? DrawerColorConstants.selectedText
-                                  : DrawerColorConstants.lightText,
-                              BlendMode.srcIn)),
-                    ))),
+                            : DrawerColorConstants.lightText))),
                 Container(
                   width: 20,
                 ),

--- a/lib/drawer/ui/module.dart
+++ b/lib/drawer/ui/module.dart
@@ -33,12 +33,10 @@ class ModuleUI extends HookConsumerWidget {
                 Container(
                   width: 25,
                 ),
-                SizedBox(
-                    height: 50,
-                    child: Center(
-                        child: m.getIcon(m.root == QR.currentPath
-                            ? DrawerColorConstants.selectedText
-                            : DrawerColorConstants.lightText))),
+                Center(
+                    child: m.getIcon(m.root == QR.currentPath
+                        ? DrawerColorConstants.selectedText
+                        : DrawerColorConstants.lightText)),
                 Container(
                   width: 20,
                 ),

--- a/lib/drawer/ui/module.dart
+++ b/lib/drawer/ui/module.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -37,11 +38,19 @@ class ModuleUI extends HookConsumerWidget {
                 SizedBox(
                     height: 50,
                     child: Center(
-                        child: HeroIcon(
-                      m.icon,
-                      color: m.root == QR.currentPath
-                          ? DrawerColorConstants.selectedText
-                          : DrawerColorConstants.lightText,
+                        child: m.icon.fold(
+                      (heroIcon) => HeroIcon(
+                        heroIcon,
+                        color: m.root == QR.currentPath
+                            ? DrawerColorConstants.selectedText
+                            : DrawerColorConstants.lightText,
+                      ),
+                      (svgPath) => SvgPicture.asset(svgPath,
+                          colorFilter: ColorFilter.mode(
+                              m.root == QR.currentPath
+                                  ? DrawerColorConstants.selectedText
+                                  : DrawerColorConstants.lightText,
+                              BlendMode.srcIn)),
                     ))),
                 Container(
                   width: 20,

--- a/lib/event/router.dart
+++ b/lib/event/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -18,7 +19,7 @@ class EventRouter {
   static const String detail = '/detail';
   static final Module module = Module(
       name: "Évenements",
-      icon: HeroIcons.calendar,
+      icon: const Left(HeroIcons.calendar),
       root: EventRouter.root,
       selected: false);
   EventRouter(this.ref);

--- a/lib/home/router.dart
+++ b/lib/home/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -10,7 +11,7 @@ class HomeRouter {
   static const String root = '/home';
   static final Module module = Module(
       name: "Calendrier",
-      icon: HeroIcons.calendarDays,
+      icon: const Left(HeroIcons.calendarDays),
       root: HomeRouter.root,
       selected: false);
   HomeRouter(this.ref);

--- a/lib/loan/router.dart
+++ b/lib/loan/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -20,7 +21,7 @@ class LoanRouter {
   static const String detail = '/detail';
   static final Module module = Module(
       name: "Prêt",
-      icon: HeroIcons.buildingLibrary,
+      icon: const Left(HeroIcons.buildingLibrary),
       root: LoanRouter.root,
       selected: false);
   LoanRouter(this.ref);

--- a/lib/settings/ui/pages/modules_page/modules_page.dart
+++ b/lib/settings/ui/pages/modules_page/modules_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:myecl/drawer/class/module.dart';
 import 'package:myecl/settings/providers/module_list_provider.dart';
 import 'package:myecl/settings/ui/settings.dart';
 
@@ -50,14 +48,7 @@ class ModulesPage extends HookConsumerWidget {
                 padding: const EdgeInsets.symmetric(vertical: 5),
                 child: Row(
                   children: [
-                    module.icon.fold(
-                        (heroIcon) => HeroIcon(
-                              heroIcon,
-                              color: Colors.grey.shade700,
-                            ),
-                        (svgPath) => SvgPicture.asset(svgPath,
-                            colorFilter: ColorFilter.mode(
-                                Colors.grey.shade700, BlendMode.srcIn))),
+                    module.getIcon(Colors.grey.shade700),
                     const SizedBox(
                       width: 20,
                     ),

--- a/lib/settings/ui/pages/modules_page/modules_page.dart
+++ b/lib/settings/ui/pages/modules_page/modules_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:myecl/drawer/class/module.dart';
 import 'package:myecl/settings/providers/module_list_provider.dart';
 import 'package:myecl/settings/ui/settings.dart';
 
@@ -48,10 +50,14 @@ class ModulesPage extends HookConsumerWidget {
                 padding: const EdgeInsets.symmetric(vertical: 5),
                 child: Row(
                   children: [
-                    HeroIcon(
-                      module.icon,
-                      color: Colors.grey.shade700,
-                    ),
+                    module.icon.fold(
+                        (heroIcon) => HeroIcon(
+                              heroIcon,
+                              color: Colors.grey.shade700,
+                            ),
+                        (svgPath) => SvgPicture.asset(svgPath,
+                            colorFilter: ColorFilter.mode(
+                                Colors.grey.shade700, BlendMode.srcIn))),
                     const SizedBox(
                       width: 20,
                     ),

--- a/lib/tombola/router.dart
+++ b/lib/tombola/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -20,7 +21,7 @@ class RaffleRouter {
   static const String tombola = '/tombola';
   static final Module module = Module(
       name: "Tombola",
-      icon: HeroIcons.gift,
+      icon: const Left(HeroIcons.gift),
       root: RaffleRouter.root,
       selected: false);
   RaffleRouter(this.ref);

--- a/lib/vote/router.dart
+++ b/lib/vote/router.dart
@@ -1,3 +1,4 @@
+import 'package:either_dart/either.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/class/module.dart';
@@ -20,7 +21,7 @@ class VoteRouter {
   static const String detail = '/detail';
   static final Module module = Module(
       name: "Vote",
-      icon: HeroIcons.envelopeOpen,
+      icon: const Left(HeroIcons.envelopeOpen),
       root: VoteRouter.root,
       selected: false);
   VoteRouter(this.ref);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  either_dart:
+    dependency: "direct main"
+    description:
+      name: either_dart
+      sha256: "0b57f6a9410ce0ba2cc340220109f545bf4bad1b06b242219f0af11ab9e84f0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   equatable:
     dependency: transitive
     description:
@@ -372,7 +380,7 @@ packages:
     source: hosted
     version: "2.0.0"
   flutter_svg:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_svg
       sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   crypto: ^3.0.2
   datetime_picker_formfield: ^2.0.1
   dotenv: ^4.0.1
+  either_dart: ^1.0.0
   fl_chart: ^0.63.0
   flash: ^3.0.5+1
   flutter:
@@ -22,8 +23,11 @@ dependencies:
   flutter_appauth: ^6.0.0
   flutter_dotenv: ^5.0.2
   flutter_hooks: ^0.18.2+1
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.1.1
   flutter_secure_storage: ^8.0.0
+  flutter_svg: ^2.0.7
   google_fonts: ^5.0.0
   heroicons: ^0.8.0
   hooks_riverpod: ^2.1.1
@@ -32,13 +36,12 @@ dependencies:
   image_cropper: ^5.0.0
   image_picker: ^1.0.0
   intl: ^0.18.0
-  flutter_localizations:
-    sdk: flutter
   jwt_decoder: ^2.0.1
   numberpicker: ^2.1.1
   package_info_plus: ^4.0.2
   path: ^1.8.2
   path_provider: ^2.0.11
+  qlevar_router: ^1.9.0
   shared_preferences: ^2.1.1
   smooth_page_indicator: ^1.0.0+2
   syncfusion_flutter_calendar: ^22.1.36
@@ -47,7 +50,6 @@ dependencies:
   url_launcher: ^6.1.7
   vector_math: ^2.1.2
   zxcvbn: ^1.0.0
-  qlevar_router: ^1.9.0
 
 dev_dependencies:
   dependency_validator: ^3.2.2


### PR DESCRIPTION
Goal of this PR : 
Enable module to have custom icons as svg as well as regular HeroIcons

Description of the added features :
- [x] module icon is now either a HeroIcon (Left option) or a svg (Right option)


Images (if the PR changes the front) :

| Desktop - Mobile |
| ----------- |
|  ![image](https://github.com/aeecleclair/Titan/assets/34400034/b77d9f44-791e-4df3-b9d9-76147eb1daf7) |
| ![image](https://github.com/aeecleclair/Titan/assets/34400034/9af79aa1-c687-4d0e-8637-4901f039adda) |

When selected

Other informations :
- Merge this PR before EloCaps, because it will required svg support
