### PR TITLE
Fix: Resetting the loading arrow when the loading popup is closed without logging in

### DIFF
--- a/lib/auth/providers/openid_provider.dart
+++ b/lib/auth/providers/openid_provider.dart
@@ -168,8 +168,6 @@ class OpenIdTokenProvider
 
         checkWindowClosed();
         completer.future.then((_) {
-          print("window closed");
-          print(state);
           state.maybeWhen(
               loading: () {
                 state = AsyncValue.data({
@@ -178,11 +176,9 @@ class OpenIdTokenProvider
                 });
               },
               orElse: () {});
-          print(state);
         });
 
         void login(String data) async {
-          print("login");
           final receivedUri = Uri.parse(data);
           final token = receivedUri.queryParameters["code"];
           if (popupWin != null) {
@@ -190,11 +186,9 @@ class OpenIdTokenProvider
             popupWin = null;
           }
           try {
-            print(token);
             if (token != null && token.isNotEmpty) {
               final resp = await openIdRepository.getToken(token, clientId,
                   redirectUri.toString(), codeVerifier, "authorization_code");
-              print(resp);
               final accessToken = resp[tokenKey]!;
               final refreshToken = resp[refreshTokenKey]!;
               await _secureStorage.write(key: tokenName, value: refreshToken);
@@ -213,7 +207,6 @@ class OpenIdTokenProvider
         }
 
         html.window.onMessage.listen((event) {
-          print("login");
           if (event.data.toString().contains('code=')) {
             login(event.data);
           }

--- a/lib/auth/repository/openid_repository.dart
+++ b/lib/auth/repository/openid_repository.dart
@@ -15,6 +15,7 @@ class OpenIdRepository extends Repository {
       "grant_type": grantType,
       "refresh_token": token,
     };
+    print(body);
 
     final Map<String, String> headers = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -25,6 +26,7 @@ class OpenIdRepository extends Repository {
           .post(Uri.parse("${host}auth/token"),
               headers: headers, body: body)
           .timeout(const Duration(seconds: 5));
+      print(response.body);
       if (response.statusCode == 200) {
         final token = jsonDecode(response.body)["access_token"];
         final refreshToken = jsonDecode(response.body)["refresh_token"];

--- a/lib/auth/repository/openid_repository.dart
+++ b/lib/auth/repository/openid_repository.dart
@@ -15,7 +15,6 @@ class OpenIdRepository extends Repository {
       "grant_type": grantType,
       "refresh_token": token,
     };
-    print(body);
 
     final Map<String, String> headers = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -26,7 +25,6 @@ class OpenIdRepository extends Repository {
           .post(Uri.parse("${host}auth/token"),
               headers: headers, body: body)
           .timeout(const Duration(seconds: 5));
-      print(response.body);
       if (response.statusCode == 200) {
         final token = jsonDecode(response.body)["access_token"];
         final refreshToken = jsonDecode(response.body)["refresh_token"];


### PR DESCRIPTION
This bug occurs when you close the logging popup window.

The arrow in the login button of the app stays in the loading state.
This happens because closing the window doesn't change the state of the isLoading provider, which still in loading.

This bug is fixed by watching the state of the popup, and changing the provider state to data if it still in loading, to prevent changing the state when the window is closed because the user logged in.