### PR TITLE
Change the way to handle closing dialog

### DIFF
--- a/lib/drawer/ui/quit_dialog.dart
+++ b/lib/drawer/ui/quit_dialog.dart
@@ -31,6 +31,9 @@ class QuitDialog extends HookConsumerWidget {
                     displayToast(
                         context, TypeMsg.msg, DrawerTextConstants.logOut);
                     displayQuitNotifier.setDisplay(false);
+                  },
+                  onNo: () {
+                    displayQuitNotifier.setDisplay(false);
                   }),
             )));
   }

--- a/lib/drawer/ui/quit_dialog.dart
+++ b/lib/drawer/ui/quit_dialog.dart
@@ -3,10 +3,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:myecl/auth/providers/openid_provider.dart';
 import 'package:myecl/drawer/providers/display_quit_popup.dart';
 import 'package:myecl/drawer/tools/constants.dart';
-import 'package:myecl/login/router.dart';
 import 'package:myecl/tools/functions.dart';
 import 'package:myecl/tools/ui/dialog.dart';
-import 'package:qlevar_router/qlevar_router.dart';
 
 class QuitDialog extends HookConsumerWidget {
   const QuitDialog({Key? key}) : super(key: key);
@@ -32,7 +30,7 @@ class QuitDialog extends HookConsumerWidget {
                     isCachingNotifier.set(false);
                     displayToast(
                         context, TypeMsg.msg, DrawerTextConstants.logOut);
-                    QR.to(LoginRouter.root);
+                    displayQuitNotifier.setDisplay(false);
                   }),
             )));
   }

--- a/lib/tools/ui/dialog.dart
+++ b/lib/tools/ui/dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:myecl/tools/constants.dart';
+import 'package:qlevar_router/qlevar_router.dart';
 
 class CustomDialogBox extends StatefulWidget {
   final String title, descriptions;
@@ -35,7 +36,7 @@ class CustomDialogBoxState extends State<CustomDialogBox> {
       ),
       elevation: 0,
       backgroundColor: Colors.transparent,
-      child: contentBox(context),
+      child: contentBox(QR.context!),
     );
   }
 

--- a/lib/tools/ui/dialog.dart
+++ b/lib/tools/ui/dialog.dart
@@ -10,6 +10,7 @@ class CustomDialogBox extends StatefulWidget {
   final Color noColor = ColorConstants.background2;
 
   final Function() onYes;
+  final Function()? onNo;
 
   static const double _padding = 20;
   static const double _avatarRadius = 45;
@@ -20,7 +21,8 @@ class CustomDialogBox extends StatefulWidget {
       {Key? key,
       required this.title,
       required this.descriptions,
-      required this.onYes})
+      required this.onYes,
+      this.onNo})
       : super(key: key);
 
   @override
@@ -87,7 +89,9 @@ class CustomDialogBoxState extends State<CustomDialogBox> {
                     children: [
                       TextButton(
                           onPressed: () {
-                            Navigator.of(context).pop();
+                            widget.onNo == null
+                                ? Navigator.of(context).pop()
+                                : widget.onNo?.call();
                           },
                           child: Text(
                             "Non",
@@ -98,7 +102,9 @@ class CustomDialogBoxState extends State<CustomDialogBox> {
                           )),
                       TextButton(
                           onPressed: () async {
-                            Navigator.of(context).pop();
+                            if (widget.onNo == null) {
+                              Navigator.of(context).pop();
+                            }
                             await widget.onYes();
                           },
                           child: Text(


### PR DESCRIPTION
Goal of this PR :  Fix a bug that was preventing the log out dialog to close.

This bug had two causes :
- The dialog was not on the routing system,and the rerouting was already handled by the auth provider through providers that depends on it.
- The context was the app one, instead of the QR one, which make the display to be supported by any of the navigator

