### PR TITLE
Reorder-Centralisation-favorite-modules

### DIFF
--- a/lib/centralisation/providers/favorites_providers.dart
+++ b/lib/centralisation/providers/favorites_providers.dart
@@ -1,6 +1,4 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:myecl/centralisation/class/module.dart';
-import 'package:myecl/centralisation/providers/centralisation_section_provider.dart';
 import 'package:myecl/tools/token_expire_wrapper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:async';
@@ -27,6 +25,17 @@ class FavoritesNameNotifier extends StateNotifier<List<String>> {
     saveFavoritesToSharedPreferences(state);
   }
 
+  void reorderFavorites(int oldIndex, int newIndex) {
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+    final copy = state.sublist(0);
+    final String item = copy.removeAt(oldIndex);
+    copy.insert(newIndex, item);
+    state = copy;
+    saveFavoritesToSharedPreferences(copy);
+  }
+
   Future<void> saveFavoritesToSharedPreferences(
       List<String> favoritesList) async {
     final prefs = await SharedPreferences.getInstance();
@@ -41,20 +50,4 @@ final favoritesNameProvider =
     favoritesNameNotifier.loadFavorites();
   });
   return favoritesNameNotifier;
-});
-
-final favoritesProvider = Provider<List<Module>>((ref) {
-  final favoritesName = ref.watch(favoritesNameProvider);
-  final sections = ref.watch(sectionProvider);
-  return sections.maybeWhen<List<Module>>(
-    data: (sections) {
-      final modules = sections
-          .map((section) => section.moduleList)
-          .expand((element) => element);
-      return modules
-          .where((module) => favoritesName.contains(module.name))
-          .toList();
-    },
-    orElse: () => [],
-  );
 });

--- a/lib/centralisation/ui/pages/main_page.dart
+++ b/lib/centralisation/ui/pages/main_page.dart
@@ -14,7 +14,22 @@ class CentralisationMainPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final section = ref.watch(sectionProvider);
-    final favorites = ref.watch(favoritesProvider);
+    final sections = ref.watch(sectionProvider);
+    final favoritesName = ref.watch(favoritesNameProvider);
+    print(favoritesName);
+    final favoritesNameNotifier = ref.read(favoritesNameProvider.notifier);
+    final favorites = sections.maybeWhen(
+      data: (sections) {
+        final modules = sections
+            .map((section) => section.moduleList)
+            .expand((element) => element);
+        return favoritesName
+            .map((name) => modules.firstWhere((module) => module.name == name))
+            .toList();
+      },
+      orElse: () => [],
+    );
+    print(favorites);
 
     return CentralisationTemplate(
       child: SingleChildScrollView(
@@ -22,21 +37,21 @@ class CentralisationMainPage extends HookConsumerWidget {
         child: Column(children: [
           Container(
             padding: const EdgeInsets.only(top: 15, bottom: 5),
-            child: SingleChildScrollView(
+            height: 135,
+            child: ReorderableListView(
               physics: const BouncingScrollPhysics(),
               scrollDirection: Axis.horizontal,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  const SizedBox(
-                    width: 15,
-                  ),
-                  ...favorites.map((module) => LikedCard(module: module)),
-                  const SizedBox(
-                    width: 15,
-                  ),
-                ],
+              header: const SizedBox(
+                width: 15,
               ),
+              footer: const SizedBox(
+                width: 15,
+              ),
+              onReorder: favoritesNameNotifier.reorderFavorites,
+              children: favorites
+                  .map((module) =>
+                      LikedCard(module: module, key: Key(module.name)))
+                  .toList(),
             ),
           ),
           ...section.when(

--- a/lib/centralisation/ui/pages/main_page.dart
+++ b/lib/centralisation/ui/pages/main_page.dart
@@ -16,7 +16,6 @@ class CentralisationMainPage extends HookConsumerWidget {
     final section = ref.watch(sectionProvider);
     final sections = ref.watch(sectionProvider);
     final favoritesName = ref.watch(favoritesNameProvider);
-    print(favoritesName);
     final favoritesNameNotifier = ref.read(favoritesNameProvider.notifier);
     final favorites = sections.maybeWhen(
       data: (sections) {
@@ -29,7 +28,6 @@ class CentralisationMainPage extends HookConsumerWidget {
       },
       orElse: () => [],
     );
-    print(favorites);
 
     return CentralisationTemplate(
       child: SingleChildScrollView(
@@ -41,6 +39,10 @@ class CentralisationMainPage extends HookConsumerWidget {
             child: ReorderableListView(
               physics: const BouncingScrollPhysics(),
               scrollDirection: Axis.horizontal,
+              proxyDecorator: (widget, _, animation) => Transform.scale(
+                scale: 1 + .05 * animation.value,
+                child: widget,
+              ),
               header: const SizedBox(
                 width: 15,
               ),


### PR DESCRIPTION
Goal of this PR : Allow to reorder favorite modules in Centralisation

Description of the added features :
- [x] Possibility to reorder modules

Other informations :
- Solve https://github.com/aeecleclair/Titan/issues/113
