### PR TITLE
Fix redirectUri for web

### DIFF
--- a/lib/auth/providers/openid_provider.dart
+++ b/lib/auth/providers/openid_provider.dart
@@ -118,6 +118,7 @@ class OpenIdTokenProvider
   final String tokenKey = "token";
   final String refreshTokenKey = "refresh_token";
   final String redirectUrl = "fr.myecl.titan://authorized";
+  final String redirectUrlHost = "myecl.fr";
   final String discoveryUrl =
       "${Repository.displayHost}.well-known/openid-configuration";
   final List<String> scopes = ["API"];
@@ -137,12 +138,9 @@ class OpenIdTokenProvider
   Future getTokenFromRequest() async {
     html.WindowBase? popupWin;
 
-    final currentUri = Uri.base;
-
     final redirectUri = Uri(
-      host: currentUri.host,
-      scheme: currentUri.scheme,
-      port: currentUri.port,
+      host: redirectUrlHost,  
+      scheme: "https",
       path: '/static.html',
     );
     final codeVerifier = generateRandomString(128);


### PR DESCRIPTION
This PR make redirect_uri static for Titan Web.

Even if it's different from localhost, authentication still work in debug mode as Titan is able to catch the auth token regardless of the redirect_uri. This allows compatibility with redirect_uri allowed from Hyperion (see aeecleclair/Hyperion#212)