### PR TITLE
Fix/seeing-details-of-past-loan

### DIFF
--- a/lib/loan/ui/pages/admin_page/item_card.dart
+++ b/lib/loan/ui/pages/admin_page/item_card.dart
@@ -25,7 +25,7 @@ class ItemCard extends StatelessWidget {
     return CardLayout(
       id: item.id,
       width: 140,
-      height: (showButtons) ? 140 : 95,
+      height: (showButtons) ? 150 : 95,
       padding: const EdgeInsets.symmetric(horizontal: 17.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/loan/ui/pages/admin_page/loan_card.dart
+++ b/lib/loan/ui/pages/admin_page/loan_card.dart
@@ -31,7 +31,7 @@ class LoanCard extends StatelessWidget {
         DateTime.now().compareTo(loan.end) > 0 && !loan.returned;
     return GestureDetector(
       onTap: () {
-        if (isAdmin) {
+        if (isAdmin || isHistory) {
           onInfo?.call();
         }
       },
@@ -41,8 +41,8 @@ class LoanCard extends StatelessWidget {
         height: (isAdmin && !isDetail)
             ? 170
             : isHistory
-                ? 110
-                : 160,
+                ? 120
+                : 180,
         colors: shouldReturn
             ? [
                 LoanColorConstants.redGradient1,

--- a/lib/loan/ui/pages/admin_page/loan_history.dart
+++ b/lib/loan/ui/pages/admin_page/loan_history.dart
@@ -4,13 +4,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:myecl/loan/providers/admin_history_loan_list_provider.dart';
 import 'package:myecl/loan/providers/history_loaner_loan_list_provider.dart';
 import 'package:myecl/loan/providers/loan_focus_provider.dart';
+import 'package:myecl/loan/providers/loan_provider.dart';
 import 'package:myecl/loan/providers/loaner_provider.dart';
+import 'package:myecl/loan/router.dart';
 import 'package:myecl/loan/tools/constants.dart';
 import 'package:myecl/loan/ui/pages/admin_page/loan_card.dart';
 import 'package:myecl/tools/ui/builders/async_child.dart';
 import 'package:myecl/tools/ui/layouts/horizontal_list_view.dart';
 import 'package:myecl/tools/ui/widgets/loader.dart';
 import 'package:myecl/tools/ui/widgets/styled_search_bar.dart';
+import 'package:qlevar_router/qlevar_router.dart';
 
 class HistoryLoan extends HookConsumerWidget {
   const HistoryLoan({super.key});
@@ -18,6 +21,7 @@ class HistoryLoan extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final loaner = ref.watch(loanerProvider);
+    final loanNotifier = ref.read(loanProvider.notifier);
     final historyLoanListNotifier =
         ref.watch(historyLoanerLoanListProvider.notifier);
     final loanList = ref.watch(historyLoanerLoanListProvider);
@@ -62,10 +66,17 @@ class HistoryLoan extends HookConsumerWidget {
                     ),
                     const SizedBox(height: 10),
                     HorizontalListView.builder(
-                        height: 110,
+                        height: 120,
                         items: data,
-                        itemBuilder: (context, loan, i) =>
-                            LoanCard(loan: loan, isHistory: true))
+                        itemBuilder: (context, loan, i) => LoanCard(
+                            loan: loan,
+                            onInfo: () {
+                              loanNotifier.setLoan(loan);
+                              QR.to(LoanRouter.root +
+                                  LoanRouter.admin +
+                                  LoanRouter.detail);
+                            },
+                            isHistory: true))
                   ],
                 );
               });

--- a/lib/loan/ui/pages/admin_page/loaners_items.dart
+++ b/lib/loan/ui/pages/admin_page/loaners_items.dart
@@ -74,7 +74,7 @@ class LoanersItems extends HookConsumerWidget {
                   ),
                   const SizedBox(height: 10),
                   HorizontalListView.builder(
-                      height: 140,
+                      height: 150,
                       firstChild: GestureDetector(
                         onTap: () {
                           itemNotifier.setItem(Item.empty());


### PR DESCRIPTION
Goal of this PR : 
- Allowing admin to tap on past loan card to see details of it
- Resizing loan and item cards
