### PR TITLE
fix: using advert date when editing

### DIFF
--- a/lib/advert/ui/pages/form_page/add_edit_advert_page.dart
+++ b/lib/advert/ui/pages/form_page/add_edit_advert_page.dart
@@ -240,7 +240,7 @@ class AdvertAddEditAdvertPage extends HookConsumerWidget {
                                   id: isEdit ? advert.id : '',
                                   announcer: selectedAnnouncers[0],
                                   content: content.text,
-                                  date: DateTime.now(),
+                                  date: isEdit ? advert.date : DateTime.now(),
                                   tags: textTagsController.text.split(', '),
                                   title: title.text);
                               final value = isEdit


### PR DESCRIPTION
Goal of this PR : Fixes 205

Description of the added features :
- [x] Not changing the date of an advert when editing it
