### PR TITLE
fix: removing wrong image bytes retrieval

### DIFF
--- a/lib/cinema/ui/pages/session_pages/add_edit_session.dart
+++ b/lib/cinema/ui/pages/session_pages/add_edit_session.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';

--- a/lib/cinema/ui/pages/session_pages/add_edit_session.dart
+++ b/lib/cinema/ui/pages/session_pages/add_edit_session.dart
@@ -110,8 +110,6 @@ class AddEditSessionPage extends HookConsumerWidget {
                                 data: (data) async {
                                   name.text = data.title;
                                   overview.text = data.overview;
-                                  logo.value =
-                                      await File(data.posterUrl).readAsBytes();
                                   posterUrl.text = data.posterUrl;
                                   genre.text = data.genres.join(', ');
                                   tagline.text = data.tagline;

--- a/lib/cinema/ui/pages/session_pages/add_edit_session.dart
+++ b/lib/cinema/ui/pages/session_pages/add_edit_session.dart
@@ -172,7 +172,7 @@ class AddEditSessionPage extends HookConsumerWidget {
                   label: CinemaTextConstants.posterUrl,
                   controller: posterUrl,
                   onChanged: (value) async {
-                    logo.value = await File(posterUrl.text).readAsBytes();
+                    logo.value = await getFromUrl(posterUrl.text);
                   },
                   canBeEmpty: true,
                 ),


### PR DESCRIPTION
Goal of this PR : Solves https://github.com/aeecleclair/Titan/issues/232

![image](https://github.com/aeecleclair/Titan/assets/34400034/e12abbda-d0ca-40da-a9df-586e2ecae438)
