### PR TITLE
fix:do not show promo text while promo is null

### DIFF
--- a/lib/settings/ui/pages/edit_user_page/edit_user_page.dart
+++ b/lib/settings/ui/pages/edit_user_page/edit_user_page.dart
@@ -185,14 +185,17 @@ class EditUserPage extends HookConsumerWidget {
                         );
                       }),
                   const SizedBox(height: 50),
-                  Text(
-                    '${SettingsTextConstants.promo} ${user.promo}',
-                    style: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w500,
-                        color: Colors.black),
-                  ),
-                  const SizedBox(height: 20),
+                  if (user.promo != null)
+                    Container(
+                      margin: const EdgeInsets.only(bottom: 20),
+                      child: Text(
+                        '${SettingsTextConstants.promo} ${user.promo}',
+                        style: const TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.black),
+                      ),
+                    ),
                   AutoSizeText(
                     '${SettingsTextConstants.email} : ${user.email}',
                     maxLines: 1,


### PR DESCRIPTION
If promo is null, as there is no possibility to edit it, there is no point in showing it on edit user page
Close #272 

Editing user while Promo is null :
![image](https://github.com/aeecleclair/Titan/assets/122213719/d7135180-f48e-4bb0-a475-17a96bb760bd)
