### PR TITLE
Remove pubspec.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,6 @@
 /build/
 /windows/flutter/generated_*
 
-# Web related
-
 # Symbolication related
 app.*.symbols
 
@@ -44,9 +42,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-
-# lock
-pubspec.lock
 
 # env 
 .env


### PR DESCRIPTION
We should remove `pubspec.lock` from `.gitignore` as the file is tracked by git and this is what should be done (https://dart.dev/guides/libraries/private-files#pubspec-lock)