### PR TITLE
Fix: autoLoad/autoLoadList

### DIFF
--- a/lib/tools/providers/map_provider.dart
+++ b/lib/tools/providers/map_provider.dart
@@ -135,7 +135,9 @@ class MapNotifier<T, E>
     });
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
-        setTData(t, AsyncData([value]));
+        if (mounted) {
+          setTData(t, AsyncData([value]));
+        }
       });
     });
   }
@@ -147,7 +149,9 @@ class MapNotifier<T, E>
     });
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
-        setTData(t, value);
+        if (mounted) {
+          setTData(t, value);
+        }
       });
     });
   }

--- a/lib/tools/providers/map_provider.dart
+++ b/lib/tools/providers/map_provider.dart
@@ -130,9 +130,7 @@ class MapNotifier<T, E>
 
   Future<void> autoLoad(
       WidgetRef ref, T t, Future<E> Function(T t) loader) async {
-    Future.delayed(const Duration(milliseconds: 1), () {
-      setTData(t, const AsyncLoading());
-    });
+    setTData(t, const AsyncLoading());
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
         if (mounted) {
@@ -144,9 +142,7 @@ class MapNotifier<T, E>
 
   Future<void> autoLoadList(WidgetRef ref, T t,
       Future<AsyncValue<List<E>>> Function(T t) loader) async {
-    Future.delayed(const Duration(milliseconds: 1), () {
-      setTData(t, const AsyncLoading());
-    });
+    setTData(t, const AsyncLoading());
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
         if (mounted) {

--- a/lib/tools/providers/map_provider.dart
+++ b/lib/tools/providers/map_provider.dart
@@ -142,6 +142,7 @@ class MapNotifier<T, E>
 
   Future<void> autoLoadList(WidgetRef ref, T t,
       Future<AsyncValue<List<E>>> Function(T t) loader) async {
+    setTData(t, const AsyncLoading());
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
         if (mounted) {

--- a/lib/tools/providers/map_provider.dart
+++ b/lib/tools/providers/map_provider.dart
@@ -142,7 +142,6 @@ class MapNotifier<T, E>
 
   Future<void> autoLoadList(WidgetRef ref, T t,
       Future<AsyncValue<List<E>>> Function(T t) loader) async {
-    setTData(t, const AsyncLoading());
     tokenExpireWrapper(ref, () async {
       loader(t).then((value) {
         if (mounted) {


### PR DESCRIPTION
Fix an error that could happen while editing a mapNotifier through AutoLoaderChild

```dart
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Bad state: Tried to use MemberPicturesNotifier after `dispose` was called.
E/flutter (14770): 
E/flutter (14770): Consider checking `mounted`.
E/flutter (14770): 
E/flutter (14770): #0      StateNotifier._debugIsMounted.<anonymous closure> (package:state_notifier/state_notifier.dart:175:9)
E/flutter (14770): #1      StateNotifier._debugIsMounted (package:state_notifier/state_notifier.dart:182:6)
E/flutter (14770): #2      StateNotifier.state (package:state_notifier/state_notifier.dart:197:12)
E/flutter (14770): #3      MapNotifier.setTData (package:myecl/tools/providers/map_provider.dart:74:12)
E/flutter (14770): #4      MapNotifier.autoLoad.<anonymous closure>.<anonymous closure> (package:myecl/tools/providers/map_provider.dart:138:9)
E/flutter (14770): #5      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:838:45)
E/flutter (14770): #6      Future._propagateToListeners (dart:async/future_impl.dart:867:13)
E/flutter (14770): #7      Future._completeWithValue (dart:async/future_impl.dart:643:5)
E/flutter (14770): <asynchronous suspension>
```