### PR TITLE
Fix: use PopScope instead of deprecated WillPopScope

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,7 @@ class MyApp extends HookConsumerWidget {
     final plausible = getPlausible();
     Future(() => animationNotifier.setController(animationController));
 
-    final myWillPopScope = PopScope(
+    final popScope = PopScope(
         canPop: false,
         onPopInvoked: (didPop) async {
           final topBarCallBack = ref.watch(topBarCallBackProvider);
@@ -102,12 +102,10 @@ class MyApp extends HookConsumerWidget {
         ));
 
     if (kIsWeb) {
-      return myWillPopScope;
+      return popScope;
     }
     return MaterialApp(
-        initialRoute: '/',
-        debugShowCheckedModeBanner: false,
-        home: myWillPopScope);
+        initialRoute: '/', debugShowCheckedModeBanner: false, home: popScope);
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,8 +50,9 @@ class MyApp extends HookConsumerWidget {
     final plausible = getPlausible();
     Future(() => animationNotifier.setController(animationController));
 
-    final myWillPopScope = WillPopScope(
-        onWillPop: () async {
+    final myWillPopScope = PopScope(
+        canPop: false,
+        onPopInvoked: (didPop) async {
           final topBarCallBack = ref.watch(topBarCallBackProvider);
           if (QR.currentPath.split('/').length <= 2) {
             final animation = ref.watch(animationProvider);
@@ -66,10 +67,10 @@ class MyApp extends HookConsumerWidget {
                 topBarCallBack.onMenu?.call();
               }
             }
-            return false;
+            return;
           }
+          QR.back();
           topBarCallBack.onBack?.call();
-          return true;
         },
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,


### PR DESCRIPTION
close #307 
Reproduce deprecated WillPopScope behavior with PopScope

https://docs.flutter.dev/release/breaking-changes/android-predictive-back#migrating-from-willpopscope-to-popscope