### PR TITLE
Remove wrong text widget on detail page

### DIFF
--- a/lib/event/ui/pages/detail_page/detail_page.dart
+++ b/lib/event/ui/pages/detail_page/detail_page.dart
@@ -1,4 +1,3 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -65,16 +64,6 @@ class DetailPage extends HookConsumerWidget {
                                 event.description,
                                 style: const TextStyle(
                                   fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              const SizedBox(height: 30),
-                              AutoSizeText(
-                                event.applicant.getName(),
-                                maxLines: 2,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  fontSize: 25,
                                   fontWeight: FontWeight.bold,
                                 ),
                               ),


### PR DESCRIPTION
We should not display firstname and surname on home page when a user go on the detail page.