### PR TITLE
Fix refresher issue

### DIFF
--- a/lib/phonebook/providers/association_member_list_provider.dart
+++ b/lib/phonebook/providers/association_member_list_provider.dart
@@ -71,6 +71,7 @@ final associationMemberListProvider = StateNotifierProvider<
       AssociationMemberListNotifier(token: token);
   tokenExpireWrapperAuth(ref, () async {
     final association = ref.watch(associationProvider);
+
     await provider.loadMembers(
       association.id,
       association.mandateYear.toString(),

--- a/lib/phonebook/providers/association_provider.dart
+++ b/lib/phonebook/providers/association_provider.dart
@@ -1,37 +1,18 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:myecl/auth/providers/openid_provider.dart';
 import 'package:myecl/phonebook/class/association.dart';
-import 'package:myecl/phonebook/repositories/association_repository.dart';
-import 'package:myecl/tools/providers/single_notifier.dart';
 
-class AssociationNotifier extends SingleNotifier<Association> {
-  final AssociationRepository associationRepository = AssociationRepository();
-  AssociationNotifier({required String token})
-      : super(const AsyncValue.loading()) {
-    associationRepository.setToken(token);
-  }
-
-  Future<AsyncValue<Association>> loadAssociation(String associationId) async {
-    return await load(
-      () async => associationRepository.getAssociation(associationId),
-    );
+class AssociationNotifier extends Notifier<Association> {
+  @override
+  Association build() {
+    return Association.empty();
   }
 
   void setAssociation(Association association) {
-    state = AsyncValue.data(association);
+    state = association;
   }
 }
 
-final asyncAssociationProvider =
-    StateNotifierProvider<AssociationNotifier, AsyncValue<Association>>((ref) {
-  final token = ref.watch(tokenProvider);
-  return AssociationNotifier(token: token);
-});
-
-final associationProvider = Provider<Association>((ref) {
-  final association = ref.watch(asyncAssociationProvider);
-  return association.maybeWhen(
-    data: (association) => association,
-    orElse: () => Association.empty(),
-  );
+final associationProvider =
+    NotifierProvider<AssociationNotifier, Association>(() {
+  return AssociationNotifier();
 });

--- a/lib/phonebook/repositories/association_repository.dart
+++ b/lib/phonebook/repositories/association_repository.dart
@@ -13,10 +13,6 @@ class AssociationRepository extends Repository {
     );
   }
 
-  Future<Association> getAssociation(String associationId) async {
-    return Association.fromJson(await getOne(associationId));
-  }
-
   Future<bool> deleteAssociation(String associationId) async {
     return await delete(associationId);
   }

--- a/lib/phonebook/ui/pages/admin_page/admin_page.dart
+++ b/lib/phonebook/ui/pages/admin_page/admin_page.dart
@@ -24,7 +24,7 @@ class AdminPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
+    final associationNotifier = ref.watch(associationProvider.notifier);
     final kindNotifier = ref.watch(associationKindProvider.notifier);
     final associationListNotifier = ref.watch(associationListProvider.notifier);
     final associationList = ref.watch(associationListProvider);

--- a/lib/phonebook/ui/pages/association_creation_page/association_creation_page.dart
+++ b/lib/phonebook/ui/pages/association_creation_page/association_creation_page.dart
@@ -29,7 +29,7 @@ class AssociationCreationPage extends HookConsumerWidget {
     final description = useTextEditingController();
     final associationListNotifier = ref.watch(associationListProvider.notifier);
     final associations = ref.watch(associationListProvider);
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
+    final associationNotifier = ref.watch(associationProvider.notifier);
     final kind = ref.watch(associationKindProvider);
     void displayToastWithContext(TypeMsg type, String msg) {
       displayToast(context, type, msg);

--- a/lib/phonebook/ui/pages/association_editor_page/association_editor_page.dart
+++ b/lib/phonebook/ui/pages/association_editor_page/association_editor_page.dart
@@ -35,7 +35,7 @@ class AssociationEditorPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final key = GlobalKey<FormState>();
     final association = ref.watch(associationProvider);
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
+    final associationNotifier = ref.watch(associationProvider.notifier);
     final associationMemberListNotifier =
         ref.watch(associationMemberListProvider.notifier);
     final associationMemberList = ref.watch(associationMemberListProvider);
@@ -57,7 +57,6 @@ class AssociationEditorPage extends HookConsumerWidget {
     return PhonebookTemplate(
       child: Refresher(
         onRefresh: () async {
-          await associationNotifier.loadAssociation(association.id);
           await associationMemberListNotifier.loadMembers(
             association.id,
             association.mandateYear.toString(),

--- a/lib/phonebook/ui/pages/association_page/association_page.dart
+++ b/lib/phonebook/ui/pages/association_page/association_page.dart
@@ -23,7 +23,6 @@ class AssociationPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final association = ref.watch(associationProvider);
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
     final associationMemberList = ref.watch(associationMemberListProvider);
     final associationMemberSortedList =
         ref.watch(associationMemberSortedListProvider);
@@ -37,7 +36,6 @@ class AssociationPage extends HookConsumerWidget {
     return PhonebookTemplate(
       child: Refresher(
         onRefresh: () async {
-          await associationNotifier.loadAssociation(association.id);
           await associationMemberListNotifier.loadMembers(
             association.id,
             association.mandateYear.toString(),

--- a/lib/phonebook/ui/pages/main_page/main_page.dart
+++ b/lib/phonebook/ui/pages/main_page/main_page.dart
@@ -23,7 +23,7 @@ class PhonebookMainPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isAdmin = ref.watch(isPhonebookAdminProvider);
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
+    final associationNotifier = ref.watch(associationProvider.notifier);
     final associationListNotifier = ref.watch(associationListProvider.notifier);
     final associationList = ref.watch(associationListProvider);
     final associationFilteredList = ref.watch(associationFilteredListProvider);

--- a/lib/phonebook/ui/pages/member_detail_page/member_detail_page.dart
+++ b/lib/phonebook/ui/pages/member_detail_page/member_detail_page.dart
@@ -18,7 +18,7 @@ class MemberDetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final memberProvider = ref.watch(completeMemberProvider);
-    final associationNotifier = ref.watch(asyncAssociationProvider.notifier);
+    final associationNotifier = ref.watch(associationProvider.notifier);
     final associationList = ref.watch(associationListProvider);
     return PhonebookTemplate(
       child: Column(


### PR DESCRIPTION
I removed the endpoint GET phonebook/associations/{association_id} because it doesn't exist in Hyperion.

It was causing issues with refresher widget on some pages of the module.