### PR TITLE
Init logs and escape messages and refactor loggers

### DIFF
--- a/lib/service/tools/setup.dart
+++ b/lib/service/tools/setup.dart
@@ -41,11 +41,8 @@ void setUpNotification(WidgetRef ref) {
             user.id,
             now.add(const Duration(days: 30)),
           );
-          logger.writeLog(
-            Log(
-              message: "Firebase messaging token registered",
-              level: LogLevel.info,
-            ),
+          logger.info(
+            "Firebase messaging token registered",
           );
           topicsNotifier.getTopics();
         });

--- a/lib/service/tools/setup.dart
+++ b/lib/service/tools/setup.dart
@@ -8,7 +8,6 @@ import 'package:myecl/service/providers/firebase_token_provider.dart';
 import 'package:myecl/service/providers/messages_provider.dart';
 import 'package:myecl/service/providers/topic_provider.dart';
 import 'package:myecl/service/repositories/notification_repository.dart';
-import 'package:myecl/tools/logs/log.dart';
 import 'package:myecl/tools/repository/repository.dart';
 import 'package:myecl/tools/token_expire_wrapper.dart';
 import 'package:myecl/user/providers/user_provider.dart';

--- a/lib/tools/logs/file_logger_output.dart
+++ b/lib/tools/logs/file_logger_output.dart
@@ -38,7 +38,7 @@ class FileLoggerOutput implements LoggerOutput {
     try {
       logFile.writeAsStringSync(logToEscapedString(log), mode: FileMode.append);
     } catch (e) {
-      print("Error writing log: $e");
+      print("Error writing log: $e"); // ignore: avoid_print
     }
   }
 

--- a/lib/tools/logs/file_logger_output.dart
+++ b/lib/tools/logs/file_logger_output.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:myecl/tools/logs/log.dart';
+import 'package:myecl/tools/logs/logger_output.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// A logger output that writes logs to a file
+class FileLoggerOutput implements LoggerOutput {
+  static const String logFileName = 'myecl.log';
+  late File logFile;
+
+  // The maximum size of the log file, in bytes
+  static const int maxFileSize = 1 * 1024 * 1024; // 1MB
+
+  /// Get the log file
+  /// If the file does not exist, create it
+  Future<File> _getLogFile() async {
+    Directory root = await getApplicationDocumentsDirectory();
+    final path = '${root.path}/$logFileName';
+    if (!(await File(path).exists())) {
+      await File(path).create();
+    }
+    return File(path);
+  }
+
+  @override
+  Future<void> init() async {
+    logFile = await _getLogFile();
+
+    // If the file is more than maxFileSize (in bytes), clear its content
+    if (await logFile.length() > maxFileSize) {
+      clearLogs();
+    }
+  }
+
+  @override
+  void writeLog(Log log) {
+    try {
+      logFile.writeAsStringSync(logToEscapedString(log), mode: FileMode.append);
+    } catch (e) {
+      print("Error writing log: $e");
+    }
+  }
+
+  /// Get the logs from the file
+  /// The logs will be returned in reverse order, the most recent at the beginning
+  @override
+  List<Log> getLogs() {
+    final String logsString = logFile.readAsStringSync();
+
+    return logsFromEscapedString(logsString);
+  }
+
+  /// Delete the content of the log file
+  @override
+  void clearLogs() {
+    logFile.writeAsStringSync("");
+  }
+
+  /// Escapes the message to be saved in a file.
+  /// The string will be formatted as follows:
+  /// [time] | [level] | [message];
+  /// The message will have all "|" replaced with "-" and all ";" replaced with "".
+  String logToEscapedString(Log log) {
+    final escapedMessage = log.message.replaceAll("|", "-").replaceAll(";", "");
+    return "${log.time.toIso8601String()} | ${log.level.name.toUpperCase()} | $escapedMessage;";
+  }
+
+  /// Return a Log object from a string that was previously escaped.
+  /// The string should be formatted as follows:
+  /// [time] | [level] | [message]
+  /// NOTE: the last ";" should not be included.
+  /// The message should have all "-" replaced with "|" and all ";" replaced with "".
+  /// If the parsing fails, a Log object with an error message will be returned.
+  static Log logFromEscapedString(String logString) {
+    if (logString.isEmpty) {
+      return Log.empty();
+    }
+    try {
+      // We want to split on "|"
+      final split = logString.split("|");
+      return Log(
+        time: DateTime.parse(split[0].trim()),
+        level: LogLevel.values.firstWhere(
+          (element) => element.name.toUpperCase() == split[1].trim(),
+        ),
+        message: split[2].trim(),
+      );
+    } catch (e) {
+      return Log(
+        level: LogLevel.error,
+        message: "Parsing log $logString failed with error $e",
+      );
+    }
+  }
+
+  /// Return a list of Log object from a string that was previously escaped.
+  /// The logs should be separated by ";"
+  /// [time] | [level] | [message];
+  /// The message should have all "-" replaced with "|" and all ";" replaced with "".
+  /// If the parsing fails, a Log object with an error message will be returned.
+  static List<Log> logsFromEscapedString(String logsString) {
+    final logs = logsString.split(";");
+    // The last element is always empty, because all logs end with ";"
+    logs.removeLast();
+    // We want to reverse the logs because the most recent is at the end
+    return logs.reversed.map((log) => logFromEscapedString(log)).toList();
+  }
+}

--- a/lib/tools/logs/log.dart
+++ b/lib/tools/logs/log.dart
@@ -21,9 +21,10 @@ class Log {
     );
   }
 
+  /// The string will be formatted as follows:
+  /// [time] | [level] | [message]
   @override
   String toString() {
-    final escapedMessage = message.replaceAll(" - ", "-").replaceAll(":", "->");
-    return "${time.toIso8601String()} - ${level.toString().split(".").last.toUpperCase()}: $escapedMessage;";
+    return "${time.toIso8601String()} | ${level.name.toUpperCase()} | $message";
   }
 }

--- a/lib/tools/logs/log.dart
+++ b/lib/tools/logs/log.dart
@@ -23,6 +23,7 @@ class Log {
 
   @override
   String toString() {
-    return "${time.toIso8601String()} - ${level.toString().split(".").last.toUpperCase()}: $message;";
+    final escapedMessage = message.replaceAll(" - ", "-").replaceAll(":", "->");
+    return "${time.toIso8601String()} - ${level.toString().split(".").last.toUpperCase()}: $escapedMessage;";
   }
 }

--- a/lib/tools/logs/logger.dart
+++ b/lib/tools/logs/logger.dart
@@ -1,72 +1,61 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
+import 'package:myecl/tools/logs/file_logger_output.dart';
 import 'package:myecl/tools/logs/log.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:myecl/tools/logs/logger_output.dart';
+import 'package:myecl/tools/logs/print_logger_output.dart';
 
 class Logger {
-  final String logFileName = 'myecl.log';
-  late File logFile;
+  LoggerOutput? loggerOutput;
+
+  /// The log level of the logger
+  /// Only logs with a level equal to or higher than this level will be written
+  LogLevel minimalLogLevel = LogLevel.warning;
 
   Logger() {
     init();
   }
 
   void init() async {
-    if (!kIsWeb) {
-      Directory root = await getApplicationDocumentsDirectory();
-      final path = '${root.path}/$logFileName';
-      if (!(await File(path).exists())) {
-        await File(path).create();
-      }
-      logFile = File(path);
+    if (kIsWeb) {
+      loggerOutput = PrintLoggerOutput();
+      await loggerOutput!.init();
+    } else {
+      loggerOutput = FileLoggerOutput();
+      await loggerOutput!.init();
     }
   }
 
-  bool writeLog(Log log) {
-    if (kIsWeb) {
-      return false;
-    }
-    try {
-      logFile.writeAsStringSync(log.toString(), mode: FileMode.append);
-      return true;
-    } catch (e) {
-      return false;
+  void writeLog(Log log) {
+    if (log.level.index >= minimalLogLevel.index) {
+      loggerOutput?.writeLog(log);
     }
   }
 
   List<Log> getLogs() {
-    if (kIsWeb) {
-      return [];
-    }
-    return logFile
-        .readAsStringSync()
-        .split(";")
-        .reversed
-        .toList()
-        .sublist(1)
-        .map((e) {
-      final split = e.split(" - ");
-      if (split.length < 2) {
-        return Log.empty().copyWith(message: e);
-      }
-      String message = split[1].split(": ").last;
-      String level = split[1].split(": ").first;
-      return Log(
-        message: message,
-        level: LogLevel.values.firstWhere(
-          (element) =>
-              element.toString().split(".").last.toUpperCase() == level,
-        ),
-        time: DateTime.parse(split[0]),
-      );
-    }).toList();
+    return loggerOutput?.getLogs() ?? [];
   }
 
   void clearLogs() {
-    if (kIsWeb) {
-      return;
-    }
-    logFile.writeAsStringSync("");
+    loggerOutput?.clearLogs();
+  }
+
+  void debug(String message) {
+    writeLog(Log(message: message, level: LogLevel.debug));
+  }
+
+  void info(String message) {
+    writeLog(Log(message: message, level: LogLevel.info));
+  }
+
+  void warning(String message) {
+    writeLog(Log(message: message, level: LogLevel.warning));
+  }
+
+  void error(String message) {
+    writeLog(Log(message: message, level: LogLevel.error));
+  }
+
+  void logException(Exception e) {
+    error(e.toString());
   }
 }

--- a/lib/tools/logs/logger.dart
+++ b/lib/tools/logs/logger.dart
@@ -18,8 +18,8 @@ class Logger {
       final path = '${root.path}/$logFileName';
       if (!(await File(path).exists())) {
         await File(path).create();
-        logFile = File(path);
       }
+      logFile = File(path);
     }
   }
 

--- a/lib/tools/logs/logger_output.dart
+++ b/lib/tools/logs/logger_output.dart
@@ -1,0 +1,15 @@
+import 'package:myecl/tools/logs/log.dart';
+
+abstract class LoggerOutput {
+  /// Initialize the logger output
+  Future<void> init();
+
+  /// Write a log to the output
+  void writeLog(Log log);
+
+  /// Get the logs from the output
+  List<Log> getLogs();
+
+  /// Clear the logs from the output
+  void clearLogs();
+}

--- a/lib/tools/logs/print_logger_output.dart
+++ b/lib/tools/logs/print_logger_output.dart
@@ -1,0 +1,24 @@
+import 'package:myecl/tools/logs/log.dart';
+import 'package:myecl/tools/logs/logger_output.dart';
+
+/// A logger output that writes logs to a file
+class PrintLoggerOutput implements LoggerOutput {
+  @override
+  Future<void> init() async {}
+
+  @override
+  void writeLog(Log log) {
+    print(log.toString());
+  }
+
+  /// Get the logs from the file
+  /// The logs will be returned in reverse order, the most recent at the beginning
+  @override
+  List<Log> getLogs() {
+    return [];
+  }
+
+  /// Delete the content of the log file
+  @override
+  void clearLogs() {}
+}

--- a/lib/tools/logs/print_logger_output.dart
+++ b/lib/tools/logs/print_logger_output.dart
@@ -8,7 +8,7 @@ class PrintLoggerOutput implements LoggerOutput {
 
   @override
   void writeLog(Log log) {
-    print(log.toString());
+    print(log.toString()); // ignore: avoid_print
   }
 
   /// Get the logs from the file

--- a/lib/tools/repository/logo_repository.dart
+++ b/lib/tools/repository/logo_repository.dart
@@ -22,21 +22,14 @@ abstract class LogoRepository extends Repository {
           await cacheManager.writeImage(ext + id + suffix, response.bodyBytes);
           return response.bodyBytes;
         } catch (e) {
-          Repository.logger.writeLog(
-            Log(
-              message: "GET $ext$id$suffix\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          Repository.logger.error(
+            "GET $ext$id$suffix\nError while decoding response",
           );
           rethrow;
         }
       } else if (response.statusCode == 403) {
-        Repository.logger.writeLog(
-          Log(
-            message:
-                "GET $ext$id$suffix\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "GET $ext$id$suffix\n${response.statusCode} ${response.body}",
         );
         String resp = utf8.decode(response.body.runes.toList());
         final decoded = json.decode(resp);
@@ -46,12 +39,8 @@ abstract class LogoRepository extends Repository {
           throw AppException(ErrorType.notFound, decoded["detail"]);
         }
       } else {
-        Repository.logger.writeLog(
-          Log(
-            message:
-                "GET $ext$id$suffix\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "GET $ext$id$suffix\n${response.statusCode} ${response.body}",
         );
         throw AppException(ErrorType.notFound, response.body);
       }
@@ -61,12 +50,8 @@ abstract class LogoRepository extends Repository {
       try {
         return await cacheManager.readImage(ext + id + suffix);
       } catch (e) {
-        Repository.logger.writeLog(
-          Log(
-            message:
-                "GET $ext$id$suffix\nError while decoding response from cache",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "GET $ext$id$suffix\nError while decoding response from cache",
         );
         cacheManager.deleteCache(ext + id + suffix);
         rethrow;
@@ -96,30 +81,19 @@ abstract class LogoRepository extends Repository {
         try {
           return json.decode(value)["success"];
         } catch (e) {
-          Repository.logger.writeLog(
-            Log(
-              message: "POST $ext$id$suffix\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          Repository.logger.error(
+            "POST $ext$id$suffix\nError while decoding response",
           );
           throw AppException(ErrorType.invalidData, e.toString());
         }
       } else if (response.statusCode == 403) {
-        Repository.logger.writeLog(
-          Log(
-            message:
-                "POST $ext$id$suffix\n${response.statusCode} ${response.reasonPhrase}",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "POST $ext$id$suffix\n${response.statusCode} ${response.reasonPhrase}",
         );
         throw AppException(ErrorType.tokenExpire, value);
       } else {
-        Repository.logger.writeLog(
-          Log(
-            message:
-                "POST $ext$id$suffix\n${response.statusCode} ${response.reasonPhrase}",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "POST $ext$id$suffix\n${response.statusCode} ${response.reasonPhrase}",
         );
         throw AppException(ErrorType.notFound, value);
       }
@@ -136,20 +110,14 @@ abstract class LogoRepository extends Repository {
         await file.writeAsBytes(response.bodyBytes);
         return file;
       } catch (e) {
-        Repository.logger.writeLog(
-          Log(
-            message: "GET $path\nError while decoding response",
-            level: LogLevel.error,
-          ),
+        Repository.logger.error(
+          "GET $path\nError while decoding response",
         );
         rethrow;
       }
     } else if (response.statusCode == 403) {
-      Repository.logger.writeLog(
-        Log(
-          message: "GET $path\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      Repository.logger.error(
+        "GET $path\n${response.statusCode} ${response.body}",
       );
       String resp = utf8.decode(response.body.runes.toList());
       final decoded = json.decode(resp);
@@ -159,11 +127,8 @@ abstract class LogoRepository extends Repository {
         throw AppException(ErrorType.notFound, decoded["detail"]);
       }
     } else {
-      Repository.logger.writeLog(
-        Log(
-          message: "GET $path\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      Repository.logger.error(
+        "GET $path\n${response.statusCode} ${response.body}",
       );
       throw AppException(ErrorType.notFound, response.body);
     }

--- a/lib/tools/repository/logo_repository.dart
+++ b/lib/tools/repository/logo_repository.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:myecl/tools/exception.dart';
-import 'package:myecl/tools/logs/log.dart';
 import 'package:myecl/tools/repository/repository.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' show join;

--- a/lib/tools/repository/repository.dart
+++ b/lib/tools/repository/repository.dart
@@ -45,21 +45,14 @@ abstract class Repository {
           }
           return jsonDecode(toDecode);
         } catch (e) {
-          logger.writeLog(
-            Log(
-              message: "GET ${ext + suffix}\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          logger.error(
+            "GET ${ext + suffix}\nError while decoding response",
           );
           return [];
         }
       } else if (response.statusCode == 403) {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + suffix}\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + suffix}\n${response.statusCode} ${response.body}",
         );
         try {
           String toDecode = response.body;
@@ -75,22 +68,15 @@ abstract class Repository {
         } on AppException {
           rethrow;
         } catch (e) {
-          logger.writeLog(
-            Log(
-              message: "GET ${ext + suffix}\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          logger.error(
+            "GET ${ext + suffix}\nError while decoding response",
           );
 
           throw AppException(ErrorType.notFound, response.body);
         }
       } else {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + suffix}\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + suffix}\n${response.statusCode} ${response.body}",
         );
         throw AppException(ErrorType.notFound, response.body);
       }
@@ -98,11 +84,8 @@ abstract class Repository {
       rethrow;
     } catch (e) {
       if (kIsWeb) {
-        logger.writeLog(
-          Log(
-            message: "GET ${ext + suffix}\nError while fetching response",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + suffix}\nError while fetching response",
         );
         return [];
       }
@@ -110,12 +93,8 @@ abstract class Repository {
         final toDecode = await cacheManager.readCache(ext + suffix);
         return jsonDecode(toDecode);
       } catch (e) {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + suffix}\nError while decoding response from cache",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + suffix}\nError while decoding response from cache",
         );
         cacheManager.deleteCache(ext + suffix);
         return [];
@@ -143,22 +122,14 @@ abstract class Repository {
           }
           return jsonDecode(toDecode);
         } catch (e) {
-          logger.writeLog(
-            Log(
-              message:
-                  "GET ${ext + id + suffix}\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          logger.error(
+            "GET ${ext + id + suffix}\nError while decoding response",
           );
           return <String, dynamic>{};
         }
       } else if (response.statusCode == 403) {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + id + suffix}\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + id + suffix}\n${response.statusCode} ${response.body}",
         );
         try {
           String toDecode = response.body;
@@ -174,22 +145,14 @@ abstract class Repository {
         } on AppException {
           rethrow;
         } catch (e) {
-          logger.writeLog(
-            Log(
-              message:
-                  "GET ${ext + id + suffix}\nError while decoding response",
-              level: LogLevel.error,
-            ),
+          logger.error(
+            "GET ${ext + id + suffix}\nError while decoding response",
           );
           throw AppException(ErrorType.notFound, response.body);
         }
       } else {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + id + suffix}\n${response.statusCode} ${response.body}",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + id + suffix}\n${response.statusCode} ${response.body}",
         );
         throw AppException(ErrorType.notFound, response.body);
       }
@@ -197,11 +160,8 @@ abstract class Repository {
       rethrow;
     } catch (e) {
       if (kIsWeb) {
-        logger.writeLog(
-          Log(
-            message: "GET ${ext + suffix}\nError while fetching response",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + suffix}\nError while fetching response",
         );
         return <String, dynamic>{};
       }
@@ -209,12 +169,8 @@ abstract class Repository {
         final toDecode = await cacheManager.readCache(ext + id + suffix);
         return jsonDecode(toDecode);
       } catch (e) {
-        logger.writeLog(
-          Log(
-            message:
-                "GET ${ext + id + suffix}\nError while decoding response from cache",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "GET ${ext + id + suffix}\nError while decoding response from cache",
         );
         cacheManager.deleteCache(ext + suffix);
         return <String, dynamic>{};
@@ -237,23 +193,16 @@ abstract class Repository {
         }
         return jsonDecode(toDecode);
       } catch (e) {
-        logger.writeLog(
-          Log(
-            message: "POST ${ext + suffix}\nError while decoding response",
-            level: LogLevel.error,
-          ),
+        logger.error(
+          "POST ${ext + suffix}\nError while decoding response",
         );
         throw AppException(ErrorType.invalidData, e.toString());
       }
     } else if (response.statusCode == 204) {
       return true;
     } else if (response.statusCode == 403) {
-      logger.writeLog(
-        Log(
-          message:
-              "POST ${ext + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      logger.error(
+        "POST ${ext + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
       if (host == displayHost) {
@@ -266,13 +215,9 @@ abstract class Repository {
         throw AppException(ErrorType.notFound, decoded["detail"]);
       }
     } else {
-      logger.writeLog(
-        Log(
-          message:
-              "POST ${ext + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
-      );
+      logger.error(
+          "POST ${ext + suffix}\n${response.statusCode} ${response.body}");
+
       throw AppException(ErrorType.notFound, response.body);
     }
   }
@@ -287,12 +232,8 @@ abstract class Repository {
     if (response.statusCode == 204 || response.statusCode == 200) {
       return true;
     } else if (response.statusCode == 403) {
-      logger.writeLog(
-        Log(
-          message:
-              "PATCH ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      logger.error(
+        "PATCH ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
       if (host == displayHost) {
@@ -305,12 +246,8 @@ abstract class Repository {
         throw AppException(ErrorType.notFound, decoded["detail"]);
       }
     } else {
-      logger.writeLog(
-        Log(
-          message:
-              "PATCH ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      logger.error(
+        "PATCH ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       throw AppException(ErrorType.notFound, response.body);
     }
@@ -325,12 +262,8 @@ abstract class Repository {
     if (response.statusCode == 204) {
       return true;
     } else if (response.statusCode == 403) {
-      logger.writeLog(
-        Log(
-          message:
-              "DELETE ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      logger.error(
+        "DELETE ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
       if (host == displayHost) {
@@ -343,12 +276,8 @@ abstract class Repository {
         throw AppException(ErrorType.notFound, decoded["detail"]);
       }
     } else {
-      logger.writeLog(
-        Log(
-          message:
-              "DELETE ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
-          level: LogLevel.error,
-        ),
+      logger.error(
+        "DELETE ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       throw AppException(ErrorType.notFound, response.body);
     }

--- a/lib/tools/repository/repository.dart
+++ b/lib/tools/repository/repository.dart
@@ -5,7 +5,6 @@ import 'package:http/http.dart' as http;
 import 'package:myecl/tools/cache/cache_manager.dart';
 import 'package:myecl/tools/exception.dart';
 import 'package:myecl/tools/functions.dart';
-import 'package:myecl/tools/logs/log.dart';
 import 'package:myecl/tools/logs/logger.dart';
 
 abstract class Repository {
@@ -216,7 +215,8 @@ abstract class Repository {
       }
     } else {
       logger.error(
-          "POST ${ext + suffix}\n${response.statusCode} ${response.body}");
+        "POST ${ext + suffix}\n${response.statusCode} ${response.body}",
+      );
 
       throw AppException(ErrorType.notFound, response.body);
     }


### PR DESCRIPTION
Add a new structure to use different LoggerOutput on the web and on mobile devices. PrintLoggerOutput can be used on the web to display logs in the console.

Closes #226 
Closes #277

### How to tests?
As we use two LoggerOutput, one on the web and one on mobile devices, the two platform should be tested.

On the web:
 - open the browser console
 - find an action that log something
 - check a message `DATE | LEVEL | MESSAGE` was printed in the console


On iOS/Android:
 - find an action that log something
 - go to settings>log
 - check that logs are readable