### PR TITLE
Use flutter service worker version template

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -154,7 +154,7 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
     <script>
-      var serviceWorkerVersion = null;
+      var serviceWorkerVersion = "{{flutter_service_worker_version}}";
       var scriptLoaded = false;
       function loadMainDartJs() {
         if (scriptLoaded) {


### PR DESCRIPTION
When running the web version, we are getting warning `Warning: In index.html:157: Local variable for "serviceWorkerVersion" is deprecated. Use "{{flutter_service_worker_version}}" template token instead.`

This pull request makes use of the {{flutter_service_worker_version}}" template token