### PR TITLE
Disable multidex

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,7 +57,6 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        multiDexEnabled true
     }
 
     signingConfigs {


### PR DESCRIPTION
We don't need mutlidex support as we are supporting Android SDK versions higher than 21.

We already deleted the generated file for multidex in this commit 2ad5cbfbe0d1ccf13a44d0ddd5edf80fa1eb8e96 but we didn't explicitly said that it should be disabled.