### PR TITLE
Enable dark mode (#408)

### DIFF
--- a/lib/drawer/providers/theme_provider.dart
+++ b/lib/drawer/providers/theme_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final themeProvider = StateNotifierProvider<ThemeNotifier, bool>((ref) {
+  ThemeNotifier themeNotifier = ThemeNotifier();
+  return themeNotifier;
+});
+
+class ThemeNotifier extends StateNotifier<bool> {
+  ThemeNotifier() : super(false);
+
+  void saveTheme() {
+    SharedPreferences.getInstance().then((pref) {
+      pref.setBool(
+        'isDarkMode',
+        state,
+      );
+    });
+  }
+
+  void loadTheme() {
+    SharedPreferences.getInstance().then((pref) {
+      state = pref.getBool("isDarkMode") ?? false;
+    });
+  }
+
+  void toggleTheme() {
+    state = !state;
+    saveTheme();
+  }
+}
+
+/*
+void loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool('isDark') ?? false;
+  }
+
+  void saveToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setBool('isDark', state);
+  }
+*/

--- a/lib/drawer/tools/constants.dart
+++ b/lib/drawer/tools/constants.dart
@@ -14,6 +14,7 @@ class DrawerTextConstants {
   static const String androidAppLink =
       "https://play.google.com/store/apps/details?id=fr.myecl.titan";
   static const String copied = "Copié !";
+  static const String darkMode = "Mode sombre";
   static const String downloadAppOnMobileDevice =
       "Ce site est la version Web de l'application MyECL. Nous vous invitons à télécharger l'application. N'utilisez ce site qu'en cas de problème avec l'application.\n";
   static const String iosAppLink =

--- a/lib/drawer/ui/bottom_bar.dart
+++ b/lib/drawer/ui/bottom_bar.dart
@@ -1,17 +1,51 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:myecl/drawer/providers/display_quit_popup.dart';
+import 'package:myecl/drawer/providers/theme_provider.dart';
 import 'package:myecl/drawer/tools/constants.dart';
 
-class BottomBar extends ConsumerWidget {
+class BottomBar extends HookConsumerWidget {
   const BottomBar({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final displayQuitNotifier = ref.watch(displayQuitProvider.notifier);
+    final isDarkTheme = ref.watch(themeProvider);
+    final themeNotifier = ref.watch(themeProvider.notifier);
+    //bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
     return Column(
       children: [
+        SizedBox(
+          height: 30,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(width: 25),
+              HeroIcon(
+                isDarkTheme ? HeroIcons.moon : HeroIcons.sun,
+                color: DrawerColorConstants.lightText,
+                size: 27,
+              ),
+              const SizedBox(width: 15),
+              Text(
+                DrawerTextConstants.darkMode,
+                style: TextStyle(
+                  color: DrawerColorConstants.lightText,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(width: 15),
+              Switch(
+                value: isDarkTheme,
+                onChanged: (v) {
+                  themeNotifier.toggleTheme();
+                },
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 30),
         SizedBox(
           height: 30,
           child: Row(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:myecl/tools/functions.dart';
 import 'package:myecl/tools/plausible/plausible_observer.dart';
 import 'package:myecl/tools/ui/layouts/app_template.dart';
 import 'package:qlevar_router/qlevar_router.dart';
+import 'package:myecl/drawer/providers/theme_provider.dart';
 
 void main() async {
   await dotenv.load();
@@ -49,6 +50,7 @@ class MyApp extends HookConsumerWidget {
     final navigatorKey = GlobalKey<NavigatorState>();
     final plausible = getPlausible();
     Future(() => animationNotifier.setController(animationController));
+    final isDarkTheme = ref.watch(themeProvider);
 
     final popScope = PopScope(
       canPop: false,
@@ -83,10 +85,16 @@ class MyApp extends HookConsumerWidget {
           GlobalCupertinoLocalizations.delegate,
         ],
         theme: ThemeData(
+          brightness: Brightness.light,
           primarySwatch: Colors.orange,
           textTheme: GoogleFonts.latoTextTheme(Theme.of(context).textTheme),
-          brightness: Brightness.light,
         ),
+        darkTheme: ThemeData(
+          brightness: Brightness.dark,
+          primarySwatch: Colors.purple,
+          textTheme: GoogleFonts.latoTextTheme(Theme.of(context).textTheme),
+        ),
+        themeMode: isDarkTheme ? ThemeMode.dark : ThemeMode.light,
         routeInformationParser: const QRouteInformationParser(),
         builder: (context, child) {
           if (child == null) {


### PR DESCRIPTION
### The switch in the UI
[x] Existence: bottom of sidebar
[x] Toggles the theme (and the icon)

### Preference
[ ] System theme as default
[ ] Remember the pref device-wise (and check it works)

### Colors
[ ] Choose a set of colors to set up a light and a dark theme, that are consistent across the app
[ ] "Factorize" colors (replace hardcoded colors with theme-provided colors everywhere)