### PR TITLE
fix: handling loading case as no data case

### DIFF
--- a/lib/tools/providers/should_notify_provider.dart
+++ b/lib/tools/providers/should_notify_provider.dart
@@ -3,6 +3,9 @@ import 'package:myecl/tools/functions.dart';
 import 'package:myecl/user/providers/user_provider.dart';
 
 final shouldNotifyProvider = Provider((ref) {
-  final user = ref.watch(userProvider);
-  return !isStudent(user.email) && isNotStaff(user.email);
+  final asyncUser = ref.watch(asyncUserProvider);
+  return asyncUser.maybeWhen(
+    data: (user) => !isStudent(user.email) && isNotStaff(user.email),
+    orElse: () => false,
+  );
 });


### PR DESCRIPTION
Prevent the Email modification popup to be display until the user data are loaded, preventing it to flash while loading the main page