### PR TITLE
Replace all host and Repository.displayHost with Repository.host

### DIFF
--- a/lib/admin/repositories/group_repository.dart
+++ b/lib/admin/repositories/group_repository.dart
@@ -45,7 +45,7 @@ class GroupRepository extends Repository {
 
   Future<bool> deleteMember(Group group, SimpleUser user) async {
     final response = await http.delete(
-      Uri.parse("$host${ext}membership"),
+      Uri.parse("${Repository.host}${ext}membership"),
       headers: headers,
       body: json.encode({"user_id": user.id, "group_id": group.id}),
     );

--- a/lib/auth/providers/is_connected_provider.dart
+++ b/lib/auth/providers/is_connected_provider.dart
@@ -9,8 +9,7 @@ class IsConnectedProvider extends StateNotifier<bool> {
 
   Future isInternet() async {
     try {
-      final result =
-          await http.get(Uri.parse("${Repository.displayHost}information"));
+      final result = await http.get(Uri.parse("${Repository.host}information"));
       state = result.statusCode < 400;
     } catch (e) {
       state = false;

--- a/lib/auth/providers/openid_provider.dart
+++ b/lib/auth/providers/openid_provider.dart
@@ -121,7 +121,7 @@ class OpenIdTokenProvider
   final String redirectUrl = "${getTitanPackageName()}://authorized";
   final String redirectUrlHost = "myecl.fr";
   final String discoveryUrl =
-      "${Repository.displayHost}.well-known/openid-configuration";
+      "${Repository.host}.well-known/openid-configuration";
   final List<String> scopes = ["API"];
   OpenIdTokenProvider() : super(const AsyncValue.loading());
 
@@ -147,7 +147,7 @@ class OpenIdTokenProvider
     final codeVerifier = generateRandomString(128);
 
     final authUrl =
-        "${Repository.displayHost}auth/authorize?client_id=$clientId&response_type=code&scope=${scopes.join(" ")}&redirect_uri=$redirectUri&code_challenge=${hash(codeVerifier)}&code_challenge_method=S256";
+        "${Repository.host}auth/authorize?client_id=$clientId&response_type=code&scope=${scopes.join(" ")}&redirect_uri=$redirectUri&code_challenge=${hash(codeVerifier)}&code_challenge_method=S256";
 
     state = const AsyncValue.loading();
     try {

--- a/lib/auth/repository/openid_repository.dart
+++ b/lib/auth/repository/openid_repository.dart
@@ -27,7 +27,8 @@ class OpenIdRepository extends Repository {
     };
     try {
       final response = await http
-          .post(Uri.parse("${host}auth/token"), headers: headers, body: body)
+          .post(Uri.parse("${Repository.host}auth/token"),
+              headers: headers, body: body)
           .timeout(const Duration(seconds: 5));
       if (response.statusCode == 200) {
         final token = jsonDecode(response.body)["access_token"];

--- a/lib/centralisation/repositories/section_repository.dart
+++ b/lib/centralisation/repositories/section_repository.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 
 class SectionRepository {
   static const String host =
-      "https://centralisation.eclair.ec-lyon.fr/links.json";
+      "https://centralisation.myecl.fr/links.json";
   final Map<String, String> headers = {
     "Content-Type": "application/json; charset=UTF-8",
     "Accept": "application/json",

--- a/lib/centralisation/repositories/section_repository.dart
+++ b/lib/centralisation/repositories/section_repository.dart
@@ -7,7 +7,7 @@ class SectionRepository extends Repository {
   final host = "https://centralisation.eclair.ec-lyon.fr/links.json";
 
   Future<List<Section>> getSectionList() async {
-    final data = await getOne("", decode: true) as Map<String, dynamic>;
+    final data = await getOne("") as Map<String, dynamic>;
     return data
         .map((key, value) => MapEntry(key, Section.fromJson(key, value)))
         .values

--- a/lib/centralisation/repositories/section_repository.dart
+++ b/lib/centralisation/repositories/section_repository.dart
@@ -4,8 +4,7 @@ import 'package:myecl/tools/logs/logger.dart';
 import 'dart:convert';
 
 class SectionRepository {
-  static const String host =
-      "https://centralisation.myecl.fr/links.json";
+  static const String host = "https://centralisation.myecl.fr/links.json";
   final Map<String, String> headers = {
     "Content-Type": "application/json; charset=UTF-8",
     "Accept": "application/json",

--- a/lib/centralisation/repositories/section_repository.dart
+++ b/lib/centralisation/repositories/section_repository.dart
@@ -1,16 +1,49 @@
 import 'package:myecl/centralisation/class/section.dart';
-import 'package:myecl/tools/repository/repository.dart';
+import 'package:http/http.dart' as http;
+import 'package:myecl/tools/logs/logger.dart';
+import 'dart:convert';
 
-class SectionRepository extends Repository {
-  @override
-  // ignore: overridden_fields
-  final host = "https://centralisation.eclair.ec-lyon.fr/links.json";
+class SectionRepository {
+  static const String host =
+      "https://centralisation.eclair.ec-lyon.fr/links.json";
+  final Map<String, String> headers = {
+    "Content-Type": "application/json; charset=UTF-8",
+    "Accept": "application/json",
+  };
+
+  static final Logger logger = Logger();
+  void initLogger() {
+    logger.init();
+  }
 
   Future<List<Section>> getSectionList() async {
-    final data = await getOne("") as Map<String, dynamic>;
-    return data
-        .map((key, value) => MapEntry(key, Section.fromJson(key, value)))
-        .values
-        .toList();
+    try {
+      final response = await http.get(Uri.parse(host), headers: headers);
+      if (response.statusCode == 200) {
+        try {
+          String toDecode = utf8.decode(response.body.runes.toList());
+          final data = jsonDecode(toDecode) as Map<String, dynamic>;
+          return data
+              .map((key, value) => MapEntry(key, Section.fromJson(key, value)))
+              .values
+              .toList();
+        } catch (e) {
+          logger.error(
+            "GET $host\nError while decoding response",
+          );
+          return <Section>[];
+        }
+      } else {
+        logger.error(
+          "GET $host\n${response.statusCode} ${response.body}",
+        );
+        return <Section>[];
+      }
+    } catch (e) {
+      logger.error(
+        "GET $host\nError while fetching response",
+      );
+      return <Section>[];
+    }
   }
 }

--- a/lib/centralisation/tools/constants.dart
+++ b/lib/centralisation/tools/constants.dart
@@ -3,7 +3,7 @@ class CentralisationTextConstants {
   static const String close = 'Fermer';
   static const String error = "Erreur";
   static const String imagePath =
-      "https://centralisation.eclair.ec-lyon.fr/assets/icons/";
+      "https://centralisation.myecl.fr/assets/icons/";
   static const String openLink = 'Accéder au site';
   static const String unableToOpen = "Impossible d'ouvrir le lien";
 }

--- a/lib/settings/ui/pages/main_page/main_page.dart
+++ b/lib/settings/ui/pages/main_page/main_page.dart
@@ -168,7 +168,7 @@ class SettingsMainPage extends HookConsumerWidget {
                     onTap: () {
                       Clipboard.setData(
                         ClipboardData(
-                          text: "${Repository.displayHost}calendar/ical",
+                          text: "${Repository.host}calendar/ical",
                         ),
                       ).then((value) {
                         displayToastWithContext(
@@ -295,7 +295,7 @@ class SettingsMainPage extends HookConsumerWidget {
                   ),
                   const SizedBox(height: 10),
                   AutoSizeText(
-                    Repository.displayHost,
+                    Repository.host,
                     maxLines: 1,
                     minFontSize: 10,
                     style: const TextStyle(

--- a/lib/tools/repository/logo_repository.dart
+++ b/lib/tools/repository/logo_repository.dart
@@ -14,8 +14,8 @@ abstract class LogoRepository extends Repository {
 
   Future<Uint8List> getLogo(String id, {String suffix = ""}) async {
     try {
-      final response =
-          await http.get(Uri.parse("$host$ext$id$suffix"), headers: headers);
+      final response = await http
+          .get(Uri.parse("${Repository.host}$ext$id$suffix"), headers: headers);
       if (response.statusCode == 200) {
         try {
           return response.bodyBytes;
@@ -57,17 +57,17 @@ abstract class LogoRepository extends Repository {
     String id, {
     String suffix = "",
   }) async {
-    final request =
-        http.MultipartRequest('POST', Uri.parse("$host$ext$id$suffix"))
-          ..headers.addAll(headers)
-          ..files.add(
-            http.MultipartFile.fromBytes(
-              'image',
-              bytes,
-              filename: 'image',
-              contentType: MediaType('image', 'jpeg'),
-            ),
-          );
+    final request = http.MultipartRequest(
+        'POST', Uri.parse("${Repository.host}$ext$id$suffix"))
+      ..headers.addAll(headers)
+      ..files.add(
+        http.MultipartFile.fromBytes(
+          'image',
+          bytes,
+          filename: 'image',
+          contentType: MediaType('image', 'jpeg'),
+        ),
+      );
     final response = await request.send();
     response.stream.transform(utf8.decoder).listen((value) async {
       if (response.statusCode == 201) {

--- a/lib/tools/repository/pdf_repository.dart
+++ b/lib/tools/repository/pdf_repository.dart
@@ -15,8 +15,8 @@ abstract class PdfRepository extends Repository {
 
   Future<Uint8List> getPdf(String id, {String suffix = ""}) async {
     try {
-      final response =
-          await http.get(Uri.parse("$host$ext$id$suffix"), headers: headers);
+      final response = await http
+          .get(Uri.parse("${Repository.host}$ext$id$suffix"), headers: headers);
       if (response.statusCode == 200) {
         try {
           return response.bodyBytes;
@@ -72,17 +72,17 @@ abstract class PdfRepository extends Repository {
     String id, {
     String suffix = "",
   }) async {
-    final request =
-        http.MultipartRequest('POST', Uri.parse("$host$ext$id$suffix"))
-          ..headers.addAll(headers)
-          ..files.add(
-            http.MultipartFile.fromBytes(
-              'pdf',
-              bytes,
-              filename: 'pdf',
-              contentType: MediaType('application', 'pdf'),
-            ),
-          );
+    final request = http.MultipartRequest(
+        'POST', Uri.parse("${Repository.host}$ext$id$suffix"))
+      ..headers.addAll(headers)
+      ..files.add(
+        http.MultipartFile.fromBytes(
+          'pdf',
+          bytes,
+          filename: 'pdf',
+          contentType: MediaType('application', 'pdf'),
+        ),
+      );
     final response = await request.send();
     response.stream.transform(utf8.decoder).listen((value) async {
       if (response.statusCode == 201) {

--- a/lib/tools/repository/repository.dart
+++ b/lib/tools/repository/repository.dart
@@ -99,7 +99,6 @@ abstract class Repository {
   Future<dynamic> getOne(
     String id, {
     String suffix = "",
-    bool decode = false,
   }) async {
     try {
       final response =

--- a/lib/tools/repository/repository.dart
+++ b/lib/tools/repository/repository.dart
@@ -8,9 +8,7 @@ import 'package:myecl/tools/functions.dart';
 import 'package:myecl/tools/logs/logger.dart';
 
 abstract class Repository {
-  final String host = getTitanHost();
-
-  static final String displayHost = getTitanHost();
+  static final String host = getTitanHost();
   static const String expiredTokenDetail = "Could not validate credentials";
   final String ext = "";
   final Map<String, String> headers = {
@@ -36,9 +34,7 @@ abstract class Repository {
       if (response.statusCode == 200) {
         try {
           String toDecode = response.body;
-          if (host == displayHost) {
-            toDecode = utf8.decode(response.body.runes.toList());
-          }
+          toDecode = utf8.decode(response.body.runes.toList());
           if (!kIsWeb) {
             cacheManager.writeCache(ext + suffix, toDecode);
           }
@@ -55,9 +51,7 @@ abstract class Repository {
         );
         try {
           String toDecode = response.body;
-          if (host == displayHost) {
-            toDecode = utf8.decode(response.body.runes.toList());
-          }
+          toDecode = utf8.decode(response.body.runes.toList());
           final decoded = jsonDecode(toDecode);
           if (decoded["detail"] == expiredTokenDetail) {
             throw AppException(ErrorType.tokenExpire, decoded["detail"]);
@@ -113,9 +107,7 @@ abstract class Repository {
       if (response.statusCode == 200) {
         try {
           String toDecode = response.body;
-          if (host == displayHost || decode) {
-            toDecode = utf8.decode(response.body.runes.toList());
-          }
+          toDecode = utf8.decode(response.body.runes.toList());
           if (!kIsWeb) {
             cacheManager.writeCache(ext + id + suffix, toDecode);
           }
@@ -132,9 +124,7 @@ abstract class Repository {
         );
         try {
           String toDecode = response.body;
-          if (host == displayHost) {
-            toDecode = utf8.decode(response.body.runes.toList());
-          }
+          toDecode = utf8.decode(response.body.runes.toList());
           final decoded = jsonDecode(toDecode);
           if (decoded["detail"] == expiredTokenDetail) {
             throw AppException(ErrorType.tokenExpire, decoded["detail"]);
@@ -187,9 +177,7 @@ abstract class Repository {
     if (response.statusCode == 201) {
       try {
         String toDecode = response.body;
-        if (host == displayHost) {
-          toDecode = utf8.decode(response.body.runes.toList());
-        }
+        toDecode = utf8.decode(response.body.runes.toList());
         return jsonDecode(toDecode);
       } catch (e) {
         logger.error(
@@ -204,9 +192,7 @@ abstract class Repository {
         "POST ${ext + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
-      if (host == displayHost) {
-        toDecode = utf8.decode(response.body.runes.toList());
-      }
+      toDecode = utf8.decode(response.body.runes.toList());
       final decoded = jsonDecode(toDecode);
       if (decoded["detail"] == expiredTokenDetail) {
         throw AppException(ErrorType.tokenExpire, decoded["detail"]);
@@ -236,9 +222,7 @@ abstract class Repository {
         "PATCH ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
-      if (host == displayHost) {
-        toDecode = utf8.decode(response.body.runes.toList());
-      }
+      toDecode = utf8.decode(response.body.runes.toList());
       final decoded = jsonDecode(toDecode);
       if (decoded["detail"] == expiredTokenDetail) {
         throw AppException(ErrorType.tokenExpire, decoded["detail"]);
@@ -266,9 +250,7 @@ abstract class Repository {
         "DELETE ${ext + tId + suffix}\n${response.statusCode} ${response.body}",
       );
       String toDecode = response.body;
-      if (host == displayHost) {
-        toDecode = utf8.decode(response.body.runes.toList());
-      }
+      toDecode = utf8.decode(response.body.runes.toList());
       final decoded = jsonDecode(toDecode);
       if (decoded["detail"] == expiredTokenDetail) {
         throw AppException(ErrorType.tokenExpire, decoded["detail"]);


### PR DESCRIPTION
Fix #444
However, the `decode` argument in getOne seems useless: now it's an unused argument, and its only appearance was here
https://github.com/aeecleclair/Titan/blob/318f0b3a09b1f8a4a54a8bd5a725a5df70d6de35/lib/tools/repository/repository.dart#L116
which evaluates to `true || decode` which is true no matter the value of `decode`