### PR TITLE
Bump version 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: myecl
 description: MyECL est l'application des Centraliens de Lyon, conçue par ÉCLAIR
 
 publish_to: "none"
-version: 0.10.5+136
+version: 1.0.0+137
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
> [!IMPORTANT]
>  We really need to release new versions **soon**, as we have not for several months and there's some time needed to test in alpha before prod.

This goes hand in hand with the **major version bump** [for Hyperion](../../Hyperion/pull/642).

Both PRs are ready, and _seemingly_ waiting for some more **breaking changes** to be merged, including (by likelihood):

- [x] Support Flutter 3.27: #464
- [ ] Allow students from other Schools to have a MyECL account: #447 
- [ ] MyECLPay: #72 (old PR but recent branch)
- [ ] "_Centrale Mega Meme_" Meme module: #461 
- [x] External Notifications: #448 