### PR TITLE
Re-enforce Flutter 3.27

### DIFF
--- a/lib/admin/ui/pages/group_page/group_button.dart
+++ b/lib/admin/ui/pages/group_page/group_button.dart
@@ -26,7 +26,7 @@ class GroupButton extends StatelessWidget {
         ),
         boxShadow: [
           BoxShadow(
-            color: gradient2.withOpacity(0.3),
+            color: gradient2.withValues(alpha: 0.3),
             spreadRadius: 2,
             blurRadius: 4,
             offset: const Offset(2, 3),

--- a/lib/admin/ui/pages/main_page/menu_card_ui.dart
+++ b/lib/admin/ui/pages/main_page/menu_card_ui.dart
@@ -16,7 +16,7 @@ class MenuCardUi extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
         boxShadow: [
           BoxShadow(
-            color: Colors.grey.withOpacity(0.2),
+            color: Colors.grey.withValues(alpha: 0.2),
             blurRadius: 5,
             spreadRadius: 2,
           ),

--- a/lib/advert/ui/pages/detail_page/detail.dart
+++ b/lib/advert/ui/pages/detail_page/detail.dart
@@ -69,7 +69,7 @@ class AdvertDetailPage extends HookConsumerWidget {
                     end: Alignment.bottomCenter,
                     colors: [
                       const Color.fromARGB(0, 255, 255, 255),
-                      Colors.grey.shade50..withValues(alpha: 0.85),
+                      Colors.grey.shade50.withValues(alpha: 0.85),
                       Colors.grey.shade50,
                     ],
                     stops: const [0.0, 0.65, 1.0],

--- a/lib/amap/ui/pages/list_products_page/list_products_page.dart
+++ b/lib/amap/ui/pages/list_products_page/list_products_page.dart
@@ -39,7 +39,7 @@ class ListProductPage extends HookConsumerWidget {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
-                    Colors.white..withValues(alpha: 1.0),
+                    Colors.white,
                     Colors.white.withValues(alpha: 0.8),
                     Colors.white.withValues(alpha: 0.0),
                   ],

--- a/lib/cinema/ui/pages/detail_page/detail_page.dart
+++ b/lib/cinema/ui/pages/detail_page/detail_page.dart
@@ -90,7 +90,7 @@ class DetailPage extends HookConsumerWidget {
                     end: Alignment.bottomCenter,
                     colors: [
                       Colors.transparent,
-                      Colors.grey.shade50..withValues(alpha: 0.85),
+                      Colors.grey.shade50.withValues(alpha: 0.85),
                       Colors.grey.shade50,
                     ],
                     stops: const [0.0, 0.65, 1.0],
@@ -256,7 +256,7 @@ class DetailPage extends HookConsumerWidget {
                   end: Alignment.bottomCenter,
                   colors: [
                     const Color.fromARGB(0, 255, 255, 255),
-                    Colors.grey.shade50..withValues(alpha: 0.85),
+                    Colors.grey.shade50.withValues(alpha: 0.85),
                     Colors.grey.shade50,
                   ],
                   stops: const [0.0, 0.25, 1.0],

--- a/lib/login/ui/pages/create_account_page/create_account_page.dart
+++ b/lib/login/ui/pages/create_account_page/create_account_page.dart
@@ -227,7 +227,7 @@ class CreateAccountPage extends HookConsumerWidget {
                 floor.text = value.toString();
               },
               dropdownColor: ColorConstants.background2,
-              iconEnabledColor: Colors.grey.shade100..withValues(alpha: 0.8),
+              iconEnabledColor: Colors.grey.shade100.withValues(alpha: 0.8),
               style: const TextStyle(fontSize: 20, color: Colors.white),
               decoration: const InputDecoration(
                 contentPadding: EdgeInsets.symmetric(vertical: 10),

--- a/lib/phonebook/ui/pages/association_editor_page/association_editor_page.dart
+++ b/lib/phonebook/ui/pages/association_editor_page/association_editor_page.dart
@@ -292,7 +292,8 @@ class AssociationEditorPage extends HookConsumerWidget {
                                         ),
                                       );
                                       if (QR.currentPath.contains(
-                                          PhonebookRouter.associationDetail)) {
+                                        PhonebookRouter.associationDetail,
+                                      )) {
                                         kindNotifier.setKind("");
                                         QR.to(
                                           PhonebookRouter.root +

--- a/lib/phonebook/ui/pages/association_page/association_page.dart
+++ b/lib/phonebook/ui/pages/association_page/association_page.dart
@@ -110,7 +110,9 @@ class AssociationPage extends HookConsumerWidget {
                     },
                     child: Container(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 8),
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(10),
                         gradient: const RadialGradient(
@@ -128,7 +130,9 @@ class AssociationPage extends HookConsumerWidget {
                             spreadRadius: 5,
                             blurRadius: 10,
                             offset: const Offset(
-                                3, 3), // changes position of shadow
+                              3,
+                              3,
+                            ), // changes position of shadow
                           ),
                         ],
                       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1259,7 +1259,7 @@ packages:
     source: hosted
     version: "3.1.3"
   uuid:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1259,7 +1259,7 @@ packages:
     source: hosted
     version: "3.1.3"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff


### PR DESCRIPTION
* Trailing commas
* Again this `.withValues` since 3.27:
  * Mainly a continuation of #482 : it seems @Rotheem's global replace in #464 of `.withOpacity` failed, given that it created a `..withValues` in a couple places, leading to some colors being not rendered
  * ensure there are no `withOpacity` left: @Rotheem's #447 had re-introduced two occurrences...
