### PR TITLE
Don't build ipa on release

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -96,19 +96,19 @@ jobs:
         if: needs.extract-version.outputs.isAlpha == 'true'
         run: |
           echo $GOOGLE_SERVICES_ALPHA_JSON_BASE64 | base64 -D -o android/app/src/alpha/google-services.json
-          echo $GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64 | base64 -D -o ios/config/Alpha/GoogleService-Info.plist
+         #echo $GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64 | base64 -D -o ios/config/Alpha/GoogleService-Info.plist
         env:
           GOOGLE_SERVICES_ALPHA_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_ALPHA_JSON_BASE64 }}
-          GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64 }}
+          #GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_ALPHA_PLIST_BASE64 }}
 
       - name: Add Firebase configuration for production
         if: needs.extract-version.outputs.isAlpha == 'false'
         run: |
           echo $GOOGLE_SERVICES_JSON_BASE64 | base64 -D -o android/app/src/prod/google-services.json
-          echo $GOOGLE_SERVICE_INFO_PLIST_BASE64 | base64 -D -o ios/config/Prod/GoogleService-Info.plist
+         #echo $GOOGLE_SERVICE_INFO_PLIST_BASE64 | base64 -D -o ios/config/Prod/GoogleService-Info.plist
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
-          GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
+          #GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
 
       - name: Create the Keystore
         if: matrix.name == 'AAB'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -32,7 +32,7 @@ jobs:
 
   build-and-deploy-mobile:
     name: Release Titan ${{ needs.extract-version.outputs.tag }} ${{ matrix.name }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [extract-version]
     strategy:
       fail-fast: false
@@ -41,9 +41,9 @@ jobs:
           - target: "appbundle"
             name: "AAB"
             path: build/app/outputs/bundle/*Release/app-*-release.aab
-          - target: "ipa --no-codesign"
-            name: "IPA"
-            path: build/ios/ipa/*.ipa
+          # - target: "ipa --no-codesign"
+          #   name: "IPA"
+          #   path: build/ios/ipa/*.ipa
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
as we don't currently use the IPA build by the workflow.

We should not build Android appbundle on a macos worker