### PR TITLE
feat(urls-router): implement ID-based detail URLs for external fetching

### DIFF
--- a/lib/advert/router.dart
+++ b/lib/advert/router.dart
@@ -25,7 +25,7 @@ class AdvertRouter {
   static const String admin = '/admin';
   static const String addEditAdvert = '/add_edit_advert';
   static const String addRemAnnouncer = '/add_remove_announcer';
-  static const String detail = '/detail';
+  static const String detail = '/:advertId';
   static final Module module = Module(
     name: "Annonce",
     icon: const Left(HeroIcons.megaphone),

--- a/lib/advert/ui/components/advert_card.dart
+++ b/lib/advert/ui/components/advert_card.dart
@@ -31,11 +31,7 @@ class AdvertCard extends HookConsumerWidget {
     final posterNotifier = ref.watch(advertPosterProvider.notifier);
     final isWebFormat = ref.watch(isWebFormatProvider);
     return GestureDetector(
-      onTap: () {
-        if (!isWebFormat) {
-          onTap();
-        }
-      },
+      onTap: onTap,
       child: Container(
         margin: const EdgeInsets.all(10),
         padding: EdgeInsets.all(isWebFormat ? 50 : 0),

--- a/lib/advert/ui/pages/detail_page/detail.dart
+++ b/lib/advert/ui/pages/detail_page/detail.dart
@@ -1,11 +1,12 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:myecl/advert/providers/advert_list_provider.dart';
 import 'package:myecl/advert/providers/advert_poster_provider.dart';
 import 'package:myecl/advert/providers/advert_posters_provider.dart';
-import 'package:myecl/advert/providers/advert_provider.dart';
 import 'package:myecl/advert/ui/components/tag_chip.dart';
 import 'package:myecl/cinema/tools/functions.dart';
 import 'package:myecl/tools/ui/builders/auto_loader_child.dart';
@@ -18,12 +19,26 @@ class AdvertDetailPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final advert = ref.watch(advertProvider);
+    final advertId = QR.params['advertId'].toString();
+    final advertList = ref.watch(advertListProvider);
+    final advertPostersNotifier = ref.read(advertPostersProvider.notifier);
+    final logoNotifier = ref.read(advertPosterProvider.notifier);
+
+    final advert = advertList.whenOrNull(
+      data: (adverts) => adverts.firstWhereOrNull((a) => a.id == advertId),
+    );
+
+    if (advertList.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (advert == null) {
+      return const Center(child: Text('Advert not found'));
+    }
+
     final posters = ref.watch(
       advertPostersProvider.select((advertPosters) => advertPosters[advert.id]),
     );
-    final advertPostersNotifier = ref.watch(advertPostersProvider.notifier);
-    final logoNotifier = ref.watch(advertPosterProvider.notifier);
     final filteredTagList =
         advert.tags.where((element) => element != "").toList();
     final inTagChipsList = [advert.announcer.name] + filteredTagList;
@@ -45,7 +60,7 @@ class AdvertDetailPage extends HookConsumerWidget {
           child: AutoLoaderChild(
             group: posters,
             notifier: advertPostersNotifier,
-            mapKey: advert,
+            mapKey: advert.id,
             loader: (ref) => logoNotifier.getAdvertPoster(advert.id),
             dataBuilder: (context, value) => Image(
               image: value.first.image,

--- a/lib/advert/ui/pages/main_page/main_page.dart
+++ b/lib/advert/ui/pages/main_page/main_page.dart
@@ -11,6 +11,7 @@ import 'package:myecl/advert/ui/pages/advert.dart';
 import 'package:myecl/advert/router.dart';
 import 'package:myecl/advert/ui/components/announcer_bar.dart';
 import 'package:myecl/advert/ui/components/advert_card.dart';
+import 'package:myecl/tools/functions.dart';
 import 'package:myecl/tools/ui/builders/async_child.dart';
 import 'package:myecl/tools/ui/layouts/column_refresher.dart';
 import 'package:myecl/tools/ui/widgets/admin_button.dart';
@@ -92,7 +93,12 @@ class AdvertMainPage extends HookConsumerWidget {
                       child: AdvertCard(
                         onTap: () {
                           advertNotifier.setAdvert(advert);
-                          QR.to(AdvertRouter.root + AdvertRouter.detail);
+                          QR.to(
+                            buildPath(
+                              AdvertRouter.root + AdvertRouter.detail,
+                              [advert.id],
+                            ),
+                          );
                         },
                         advert: advert,
                       ),

--- a/lib/tools/functions.dart
+++ b/lib/tools/functions.dart
@@ -486,3 +486,30 @@ String getTitanPackageName() {
 String getTitanLogo() {
   return "assets/images/logo_${getAppFlavor()}.png";
 }
+
+/// Replaces path parameters in the given path with the provided IDs.
+///
+/// This function replaces each segment in the path that starts with a colon (`:`)
+/// with the corresponding value from the `ids` list. The number of IDs must match
+/// the number of parameters in the path.
+///
+/// Rules:
+/// - A path parameter is a substring starting with `:` and ending at the next `/` or the end of the string.
+/// - IDs must not contain `/` or `:` characters.
+/// - Replacements are applied in the order of appearance.
+///
+/// Examples:
+/// - Path: `/advert/:advertId`, IDs: `["123"]` → `/advert/123`
+/// - Path: `/advert/:advertId/:posterId`, IDs: `["123", "456"]` → `/advert/123/456`
+/// - Path: `""` → `""`
+String buildPath(String path, List<String>? ids) {
+  if (path.isEmpty || ids == null || ids.isEmpty) {
+    return path;
+  }
+
+  var newPath = path;
+  for (var i = 0; i < ids.length; i++) {
+    newPath = newPath.replaceFirst(RegExp(":[^/]+"), ids[i]);
+  }
+  return newPath;
+}


### PR DESCRIPTION
# Description:
This PRupdates route paths to use dynamic IDs (e.g., /advert/:id) instead of static paths like /advert/detail that rely on internal data.

# Goal :
Using ID-based routes enables direct access to detail pages from outside the application (e.g., via deep links or external website).


https://github.com/user-attachments/assets/99166bfb-6c48-488e-93b0-e8c56d82b800

