### PR TITLE
MyECLPay: inform of ToS mail

### DIFF
--- a/lib/paiement/ui/pages/main_page/main_page.dart
+++ b/lib/paiement/ui/pages/main_page/main_page.dart
@@ -118,7 +118,7 @@ class PaymentMainPage extends HookConsumerWidget {
                             return DeviceDialogBox(
                               title: 'Acceptation validée !',
                               descriptions:
-                                  "Merci d'avoir accepté les Conditions Générales d'Utilisation de MyECLPay. Un email de confirmation vous a été envoyé.",
+                                  """Merci d'avoir accepté la dernière version des Conditions Générales d'Utilisation de MyECLPay !\n\n Un email vous a été envoyé pour en attester.\n Vous pourrez y retrouver le contenu des Conditions Générales d'Utilisation.\n\n Vous pouvez fermer cette fenêtre et accéder à MyECLPay !""",
                               buttonText: "Ok",
                               onClick: () {},
                             );


### PR DESCRIPTION
From a feedback we have (in French):
> On a un moyen de réafficher la page des conditions d'utilisation ?

It turns out that, when accepting the ToS, users are **not informed** they received an email, which contains a permanent public link to the ToS content.

Now there's an intermediate dialog box right after the ToS are accepted, informing of the received email.
We hope that if users want to read (again) the ToS, they'll think of this email to look for it.