### PR TITLE
Use NDK 27.2.12479018 which is included by default in Ubuntu gh runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Build ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: contains(github.event.pull_request.labels.*.name, 'build')
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     name: Build ${{ matrix.name }}
+    # Using a Runner Image that include the required NDK should considerably improve performance
+    # as the build step won't require its installation
     runs-on: ubuntu-24.04
     if: contains(github.event.pull_request.labels.*.name, 'build')
     strategy:

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -10,6 +10,8 @@ jobs:
   extract-version:
     name: Determine version
     # On macOS worker `base64 -D -o` should be used instead of `base64 -d >`
+    # Using a Runner Image that include the required NDK should considerably improve performance
+    # as the build step won't require its installation
     runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.get-version.outputs.tag }}

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -10,7 +10,7 @@ jobs:
   extract-version:
     name: Determine version
     # On macOS worker `base64 -D -o` should be used instead of `base64 -d >`
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.get-version.outputs.tag }}
       isAlpha: ${{ steps.get-version.outputs.isAlpha }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,6 +34,9 @@ def keystoreProperties = new Properties()
 
 android {
     compileSdkVersion flutter.compileSdkVersion
+    // Using a NDK already included in the image used by our CI workflow
+    // should considerably improve build time
+    // See https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android
     ndkVersion "27.2.12479018"
     namespace "fr.myecl.titan"
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ def keystoreProperties = new Properties()
 
 android {
     compileSdkVersion flutter.compileSdkVersion
-    ndkVersion "27.0.12077973"
+    ndkVersion "27.2.12479018"
     namespace "fr.myecl.titan"
 
     compileOptions {


### PR DESCRIPTION
Currently, the majority of the build action is consacred to the installation of the ndk. Using a ndk available in the base image should considerably improve performance.

See
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android