### PR TITLE
Add host to android redirect scheme

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -20,7 +20,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Accepts URIs that begin with YOUR_SCHEME://YOUR_HOST -->
-                <data android:scheme="@string/flavor_url_scheme" />
+                <data android:scheme="@string/flavor_url_scheme" android:host="payment" />
             </intent-filter>
         </activity>
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Accepts URIs that begin with YOUR_SCHEME://YOUR_HOST -->
-                <data android:scheme="@string/flavor_url_scheme" />
+                <!-- Warning: only url_scheme://payment will work with this configuration -->
+                <data android:scheme="@string/flavor_url_scheme" android:host="payment" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
The current configuration is so that our personal redirect system match everything beginning with "fr.myecl.titan://" including "fr.myecl.titan://callback" from OIDC. Therefore, when logging for the first time two configurations are available and the phone will ask the user which one he wants to use. The tricky part is that our personal redirect is the first option, but it does not support the OIDC callback so almost every time the user will do the wrong choice.