### PR TITLE
Remember what store the user selected last

### DIFF
--- a/lib/paiement/providers/selected_store_provider.dart
+++ b/lib/paiement/providers/selected_store_provider.dart
@@ -9,7 +9,7 @@ class SelectedStoreNotifier extends StateNotifier<UserStore> {
   void updateStore(UserStore store) {
     state = store;
     SharedPreferences.getInstance().then((pref) {
-      pref.setString('selectedStore', store.id);
+      pref.setString('selectedStoreId', store.id);
     });
   }
 }
@@ -19,7 +19,7 @@ class LoadSelectedStoreIdProvider extends StateNotifier<String?> {
 
   void loadSelectedStoreId() {
     SharedPreferences.getInstance().then((pref) {
-      state = pref.getString('selectedStore');
+      state = pref.getString('selectedStoreId');
     });
   }
 }

--- a/lib/paiement/providers/selected_store_provider.dart
+++ b/lib/paiement/providers/selected_store_provider.dart
@@ -1,25 +1,50 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:titan/paiement/class/user_store.dart';
 import 'package:titan/paiement/providers/my_stores_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class SelectedStoreNotifier extends StateNotifier<UserStore> {
   SelectedStoreNotifier(super.store);
 
   void updateStore(UserStore store) {
     state = store;
+    SharedPreferences.getInstance().then((pref) {
+      pref.setString('selectedStore', store.id);
+    });
   }
 }
+
+class LoadSelectedStoreIdProvider extends StateNotifier<String?> {
+  LoadSelectedStoreIdProvider() : super(null);
+
+  void loadSelectedStoreId() {
+    SharedPreferences.getInstance().then((pref) {
+      state = pref.getString('selectedStore');
+    });
+  }
+}
+
+final loadSelectedStoreIdProvider =
+    StateNotifierProvider<LoadSelectedStoreIdProvider, String?>((ref) {
+      LoadSelectedStoreIdProvider loadSelectedStoreIdProvider =
+          LoadSelectedStoreIdProvider();
+      loadSelectedStoreIdProvider.loadSelectedStoreId();
+      return loadSelectedStoreIdProvider;
+    });
 
 final selectedStoreProvider =
     StateNotifierProvider<SelectedStoreNotifier, UserStore>((ref) {
       final myStores = ref.watch(myStoresProvider);
+      final selectedStoreId = ref.watch(loadSelectedStoreIdProvider);
       final store = myStores.maybeWhen<UserStore>(
         orElse: () => UserStore.empty(),
         data: (value) {
-          if (value.isEmpty) {
-            return UserStore.empty();
-          }
-          return value.first;
+          if (value.isEmpty) return UserStore.empty();
+          if (selectedStoreId == null) return value.first;
+          return value.firstWhere(
+            (store) => store.id == selectedStoreId,
+            orElse: () => value.first,
+          );
         },
       );
       return SelectedStoreNotifier(store);


### PR DESCRIPTION
Feedback: several people scanned several times for the wrong store because the default one was always the same.

Now we put in the storage the ID of the last store selected by the user, so that when s/he comes back on MyECL during an event on behalf of one club, the virtual money goes the right store.