### PR TITLE
Fix QR code scanner of purchases

### DIFF
--- a/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
+++ b/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
@@ -49,7 +49,7 @@ class QRCodeScannerScreenState extends State<QRCodeScannerScreen> {
         setState(() {
           qrCode = capture.barcodes.first.rawValue;
         });
-        widget.onScan(qrCode!);
+        if (qrCode != null) widget.onScan(qrCode!);
       },
     );
   }

--- a/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
+++ b/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
@@ -10,7 +10,7 @@ class QRCodeScannerScreen extends StatefulWidget {
     required this.scanner,
   });
 
-  final Function onScan;
+  final Function(String) onScan;
   final AsyncValue<Ticket> scanner;
 
   @override

--- a/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
+++ b/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
@@ -19,6 +19,7 @@ class QRCodeScannerScreen extends StatefulWidget {
 
 class QRCodeScannerScreenState extends State<QRCodeScannerScreen> {
   String? qrCode;
+  int scans = 0;
 
   final MobileScannerController controller = MobileScannerController();
 
@@ -46,10 +47,17 @@ class QRCodeScannerScreenState extends State<QRCodeScannerScreen> {
         );
       },
       onDetect: (BarcodeCapture capture) async {
-        setState(() {
-          qrCode = capture.barcodes.first.rawValue;
-        });
-        if (qrCode != null) widget.onScan(qrCode!);
+        var rawValue = capture.barcodes.firstOrNull?.rawValue;
+        if (rawValue != null && (rawValue != qrCode || scans <= 1)) {
+          setState(() {
+            if (rawValue != qrCode) {
+              qrCode = rawValue;
+              scans = qrCode == null ? 0 : -1;
+            }
+            scans++;
+          });
+          widget.onScan(rawValue);
+        }
       },
     );
   }

--- a/lib/purchases/ui/pages/scan_page/scan_dialog.dart
+++ b/lib/purchases/ui/pages/scan_page/scan_dialog.dart
@@ -146,37 +146,22 @@ class ScanDialog extends HookConsumerWidget {
                             );
                             scanner.when(
                               data: (data) async {
-                                scannerNotifier.setScanner(
+                                await ticketListNotifier.consumeTicket(
+                                  sellerId,
                                   data.copyWith(qrCodeSecret: secret),
+                                  ticket.id,
+                                  tag,
                                 );
-                                final value = await ticketListNotifier
-                                    .consumeTicket(
-                                      sellerId,
-                                      data,
-                                      ticket.id,
-                                      tag,
-                                    );
-                                if (value) {
-                                  displayToastWithContext(
-                                    TypeMsg.msg,
-                                    "Scan validé",
-                                  );
-                                  scannerNotifier.reset();
-                                } else {
-                                  displayToastWithContext(
-                                    TypeMsg.error,
-                                    "Erreur lors de la validation",
-                                  );
-                                }
+                                displayToastWithContext(
+                                  TypeMsg.msg,
+                                  "Scan validé",
+                                );
                               },
                               error: (error, stack) {
                                 displayToastWithContext(
                                   TypeMsg.error,
                                   error.toString(),
                                 );
-                                Future.delayed(const Duration(seconds: 2), () {
-                                  scannerNotifier.reset();
-                                });
                               },
                               loading: () {},
                             );
@@ -216,46 +201,24 @@ class ScanDialog extends HookConsumerWidget {
                           const SizedBox(height: 30),
                           Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 20),
-                            child: Row(
-                              children: [
-                                GestureDetector(
-                                  onTap: () {
-                                    scannerNotifier.reset();
-                                  },
-                                  child: const SizedBox(
-                                    width: 100,
-                                    child: AddEditButtonLayout(
-                                      color: Colors.red,
-                                      child: Text(
-                                        "Annuler",
-                                        style: TextStyle(
-                                          color: Colors.white,
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 20,
-                                        ),
-                                      ),
+                            child: GestureDetector(
+                              onTap: () {
+                                scannerNotifier.reset();
+                              },
+                              child: const SizedBox(
+                                width: 100,
+                                child: AddEditButtonLayout(
+                                  color: Colors.green,
+                                  child: Text(
+                                    "Suivant",
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 20,
                                     ),
                                   ),
                                 ),
-                                const Spacer(),
-                                GestureDetector(
-                                  onTap: () => scannerNotifier.reset(),
-                                  child: const SizedBox(
-                                    width: 100,
-                                    child: AddEditButtonLayout(
-                                      color: Colors.green,
-                                      child: Text(
-                                        "Suivant",
-                                        style: TextStyle(
-                                          color: Colors.white,
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 20,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ],
+                              ),
                             ),
                           ),
                         ],

--- a/lib/purchases/ui/pages/scan_page/scan_dialog.dart
+++ b/lib/purchases/ui/pages/scan_page/scan_dialog.dart
@@ -248,7 +248,7 @@ class ScanDialog extends HookConsumerWidget {
                                     child: AddEditButtonLayout(
                                       color: Colors.green,
                                       child: Text(
-                                        "Valider",
+                                        "Suivant",
                                         style: TextStyle(
                                           color: Colors.white,
                                           fontWeight: FontWeight.bold,

--- a/lib/purchases/ui/pages/scan_page/scan_dialog.dart
+++ b/lib/purchases/ui/pages/scan_page/scan_dialog.dart
@@ -145,10 +145,29 @@ class ScanDialog extends HookConsumerWidget {
                               ticket.id,
                             );
                             scanner.when(
-                              data: (data) {
+                              data: (data) async {
                                 scannerNotifier.setScanner(
                                   data.copyWith(qrCodeSecret: secret),
                                 );
+                                final value = await ticketListNotifier
+                                    .consumeTicket(
+                                      sellerId,
+                                      data,
+                                      ticket.id,
+                                      tag,
+                                    );
+                                if (value) {
+                                  displayToastWithContext(
+                                    TypeMsg.msg,
+                                    "Scan validé",
+                                  );
+                                  scannerNotifier.reset();
+                                } else {
+                                  displayToastWithContext(
+                                    TypeMsg.error,
+                                    "Erreur lors de la validation",
+                                  );
+                                }
                               },
                               error: (error, stack) {
                                 displayToastWithContext(
@@ -220,29 +239,7 @@ class ScanDialog extends HookConsumerWidget {
                                 ),
                                 const Spacer(),
                                 GestureDetector(
-                                  onTap: () async {
-                                    await tokenExpireWrapper(ref, () async {
-                                      final value = await ticketListNotifier
-                                          .consumeTicket(
-                                            sellerId,
-                                            data,
-                                            ticket.id,
-                                            tag,
-                                          );
-                                      if (value) {
-                                        displayToastWithContext(
-                                          TypeMsg.msg,
-                                          "Scan validé",
-                                        );
-                                        scannerNotifier.reset();
-                                      } else {
-                                        displayToastWithContext(
-                                          TypeMsg.error,
-                                          "Erreur lors de la validation",
-                                        );
-                                      }
-                                    });
-                                  },
+                                  onTap: () => scannerNotifier.reset(),
                                   child: const SizedBox(
                                     width: 100,
                                     child: AddEditButtonLayout(


### PR DESCRIPTION
* [x] Fix `onScan` argument type to actually pass the scanned secret downstream down to the request to Hyperion
* [x] replace "validate" button with "next"
* [x] send scan order immediately
* [ ] show toast on scanning
* [ ] Don't crash when tag is null

<img width="170" height="360" alt="image" src="https://github.com/user-attachments/assets/bc6283f6-acb6-45d4-ad86-d82e433dbc88" />
