### PR TITLE
Fix QR code scanner of purchases (strictly)

### DIFF
--- a/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
+++ b/lib/purchases/ui/pages/scan_page/qr_code_scanner.dart
@@ -51,7 +51,6 @@ class QRCodeScannerScreenState extends State<QRCodeScannerScreen> {
           qrCode = rawValue;
         });
         if (rawValue != null) {
-          print("onScan : $rawValue");
           widget.onScan(rawValue);
         }
       },

--- a/lib/purchases/ui/pages/scan_page/scan_dialog.dart
+++ b/lib/purchases/ui/pages/scan_page/scan_dialog.dart
@@ -137,19 +137,15 @@ class ScanDialog extends HookConsumerWidget {
                       child: QRCodeScannerScreen(
                         scanner: scanner,
                         onScan: (secret) async {
-                          print("1 onScan       : $secret");
                           await tokenExpireWrapper(ref, () async {
-                            print("2 token        : $secret");
                             await scannerNotifier.scanTicket(
                               sellerId,
                               productId,
                               secret,
                               ticket.id,
                             );
-                            print("3 scanTicket   : $secret");
                             scanner.when(
                               data: (data) {
-                                print("4 scanner.when : $secret");
                                 scannerNotifier.setScanner(
                                   data.copyWith(qrCodeSecret: secret),
                                 );
@@ -172,7 +168,6 @@ class ScanDialog extends HookConsumerWidget {
                   ),
                   scanner.when(
                     data: (data) {
-                      print("  Column avant : ${data.qrCodeSecret}");
                       final user = data.user;
                       return Column(
                         children: [


### PR DESCRIPTION
* [x] Fix `onScan` argument type to actually pass the scanned secret downstream down to the request to Hyperion
* [x] replace "validate" button with "next"