### PR TITLE
bump mobile_scanner

### DIFF
--- a/lib/paiement/ui/pages/scan_page/scanner.dart
+++ b/lib/paiement/ui/pages/scan_page/scanner.dart
@@ -35,6 +35,7 @@ class ScannerState extends ConsumerState<Scanner> with WidgetsBindingObserver {
     setState(() {
       scannedValue = null;
     });
+    controller.stop();
     controller.start();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   local_auth: ^2.3.0
   local_auth_android: ^1.0.46
   local_auth_darwin: ^1.4.1
-  mobile_scanner: 6.0.2
+  mobile_scanner: ^7.0.1
   numberpicker: ^2.1.1
   package_info_plus: ^8.3.0
   path: ^1.8.2


### PR DESCRIPTION
Need to bump mobile_scanner in order to reach 16ko compatibility.
Since v.7.0.0 scanner needs to be stopped properly before a new start().