### PR TITLE
Support Android builds for 16KB page sizes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ def keystoreProperties = new Properties()
 
 android {
     compileSdkVersion flutter.compileSdkVersion
-    ndkVersion "27.0.12077973"
+    ndkVersion "29.0.14206865"
     namespace "fr.myecl.titan"
 
     compileOptions {


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DONT'T EXPLAIN the code: JUSTIFY what this PR is for!-->

The last build failed because our NDK version is too small.
We need to be able to build for Android AND pass Google's checks to deploy to the Play Store.

<!--#### Sources at the end-->
https://developer.android.com/guide/practices/page-sizes#check-sdks

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on aeecleclair/Hyperion#-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Bump NDK version
- [x] Bump GH actions' runner to have this higher-version NDK pre-built

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [x] Other: build settings to support more RAM page sizes (historical 4 KB + new 16 KB) <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [x] No documentation needed

</details>
