### PR TITLE
Fix: bump google_fonts to use the new Flutter API to find fonts

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -641,10 +641,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      sha256: eefe5ee217f331627d8bbcf01f91b21c730bf66e225d6dc8a148370b0819168d
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "7.0.0"
   gtk:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   flutter_riverpod: ^2.1.1
   flutter_secure_storage: ^10.0.0-beta
   flutter_svg: ^2.0.7
-  google_fonts: ^6.2.1
+  google_fonts: ^7.0.0
   heroicons: ^0.11.0
   hooks_riverpod: ^2.1.1
   http: ^1.0.0


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DONT'T EXPLAIN the code: JUSTIFY what this PR is for!-->

#635 raised Flutter's version to 3.38, which, according to the [release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.38.0), has the following breaking change:
> Remove deprecated AssetManifest.json file by @matanlurey in [172594](https://github.com/flutter/flutter/pull/172594)

But `google_fonts 6.2.1` relied on this file, until 6.3.0 where, according to the [changelog](https://pub.dev/packages/google_fonts/changelog#630), they:
> Update AssetManifest to use the builtin Flutter API.

That's why `google_fonts` version ought to be bumped.

NB: 7.0.0 was released 4 days ago, without breaking changes according to the changelog, I decided to test it and it works as before #635

<!--#### Sources at the end-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Use `google_fonts 7.0.0`

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users: that's why an alpha was for: testing

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [x] Other: dependency <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [x] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [x] No documentation needed

</details>
