### PR TITLE
Correct member filtering

### DIFF
--- a/lib/phonebook/providers/association_member_sorted_list_provider.dart
+++ b/lib/phonebook/providers/association_member_sorted_list_provider.dart
@@ -11,7 +11,7 @@ final associationMemberSortedListProvider = Provider<List<CompleteMember>>((
   final association = ref.watch(associationProvider);
   return memberListProvider.maybeWhen(
     data: (members) {
-      return sortedMembers(members, association.id);
+      return sortedMembers(members, association.id, association.mandateYear);
     },
     orElse: () => List<CompleteMember>.empty(),
   );

--- a/lib/phonebook/tools/function.dart
+++ b/lib/phonebook/tools/function.dart
@@ -7,9 +7,10 @@ import 'package:titan/phonebook/class/complete_member.dart';
 import 'package:titan/phonebook/class/membership.dart';
 import 'package:titan/phonebook/providers/roles_tags_provider.dart';
 
-int getPosition(CompleteMember member, String associationId) {
+int getPosition(CompleteMember member, String associationId, int year) {
   Membership membership = member.memberships.firstWhere(
-    (element) => element.associationId == associationId,
+    (element) =>
+        element.associationId == associationId && element.mandateYear == year,
   );
   return membership.order;
 }
@@ -17,10 +18,14 @@ int getPosition(CompleteMember member, String associationId) {
 List<CompleteMember> sortedMembers(
   List<CompleteMember> members,
   String associationId,
+  int year,
 ) {
   return members..sort(
-    (a, b) =>
-        getPosition(a, associationId).compareTo(getPosition(b, associationId)),
+    (a, b) => getPosition(
+      a,
+      associationId,
+      year,
+    ).compareTo(getPosition(b, associationId, year)),
   );
 }
 


### PR DESCRIPTION
# Description

## Summary

Fix member filtering in phonebook

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on aeecleclair/Hyperion#-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [ ] No documentation needed

</details>
