### PR TITLE
Widget Previews

### DIFF
--- a/lib/tools/ui/widgets/admin_button.dart
+++ b/lib/tools/ui/widgets/admin_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:titan/tools/constants.dart';
+import 'package:flutter/widget_previews.dart';
 
 class AdminButton extends StatelessWidget {
   final VoidCallback onTap;
@@ -16,6 +17,13 @@ class AdminButton extends StatelessWidget {
     this.text = TextConstants.admin,
     this.colors,
   });
+
+  @Preview(name: "Truc", brightness: .light, size: Size(500, 500))
+  static Widget truc() {
+    return Center(
+      child: AdminButton(onTap: () {}, text: "Yo"),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1659,5 +1659,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.6 <4.0.0"


### PR DESCRIPTION
# Description

**doesn't work yet!**

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->
Flutter 3.35 added widget previews, and the ability to see these previews in the IDE using an extension.

However, the "Flutter Widget Preview" does not seem to work yet in VS Code, so this PR can only be a draft.

<!--#### Sources at the end-->
Source: https://docs.flutter.dev/tools/widget-previewer

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] AdminButton...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [x] Multiple modules changes
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [ ] No documentation needed

</details>
