### PR TITLE
Optimize(Web): gzip pre-compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.28.0-alpine3.21-slim
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY ./build/web/ /app/html
-RUN find /app/html/ -type f -regex '.*\.\(html\|css\|js\|json\|svg\|ttf\|otf\|wasm\|mjs\|symbols\)' -exec gzip -k6 {} +
+RUN find /app/html/ -type f -size +512c -regex '.*\.\(html\|css\|js\|json\|svg\|ttf\|otf\|woff2\|wasm\|mjs\|symbols\|yaml\|env\)' -exec gzip -k9 {} +

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,10 +17,10 @@ http {
     gzip_disable "msie6";
     gzip_vary on;
     gzip_proxied any;
-    gzip_comp_level 6;
+    gzip_comp_level 9;
     gzip_buffers 16 8k;
     gzip_http_version 1.1;
-    gzip_min_length 256;
+    gzip_min_length 512;
     gzip_types
       application/javascript
       text/javascript

--- a/web/index.html
+++ b/web/index.html
@@ -125,14 +125,17 @@
   </head>
   <body>
     <script
-      src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.js"
-      type="text/javascript"
+      defer
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.min.mjs"
     ></script>
-    <script type="text/javascript">
+    <script defer type="module">
+      var { pdfjsLib } = globalThis;
       pdfjsLib.GlobalWorkerOptions.workerSrc =
-        "https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.worker.min.js";
-      pdfRenderOptions = {
-        cMapUrl: "https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/cmaps/",
+        "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.mjs";
+
+      var pdfRenderOptions = {
+        cMapUrl: "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/cmaps/",
         cMapPacked: true,
       };
     </script>


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->
The web version can be unbearably slow. One way to fix it is compression.

- Compression = fewer data is transferred over the network = faster loading times (even more blatant in slow networks)
- Pre-compression = compressed once (here I included this in the building of the Docker image), served instantly from disk, no CPU overhead, and allows more aggressive levels without downsides for the client (source: the creator of gzip himself said so on StackOverflow) = even faster
- gzip = already in Nginx by default. Brotli may be even faster to decompress, and supported everywhere as well, but building a Nginx+Brotli image really is unmaintainable for us.

<!--#### Sources at the end-->
Sources:
- https://stackoverflow.com/a/37892135/30331616

## Before/after

A video is better than 1000 words: ~30% faster with a fast connection.
Can go up to 2x faster in slower networks.
Consistently 12.0-12.2s for https://titan.dev.eclair.ec-lyon.fr and 8.7-9.0s for https://titan-1.dev.eclair.ec-lyon.fr

https://github.com/user-attachments/assets/a3d00882-fd46-4221-b337-1857829246a3


## Issues/PR dependencies

Subset of the draft #646 for Nginx pre-compression.

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Nginx config: gzip config: gzip & gunzip, static, level 9, >512 bytes, mime types to take text-based files & avoid images, 
- [x] Dockerfile: include the compression there, for >512 bytes file, take text-based files & avoid image
- [x] Consistent params between the Nginx config and the compression during image build.
- [x] Re-run `flutter pub run pdfx:install_web` to regenerate the PDF script

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [x] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users
- [x] Optimization

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [x] Other: Dockerfile, Nginx config, index.html <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally: built and run my Docker image
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [x] 3. Tested in a local client using a pre-prod backend
- [x] 4. Created the 1st Titan pre-prod for the occasion
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [ ] No documentation needed

</details>
