### PR TITLE
Fix(lazy loading): defer the loading every single page that was not loaded lazily in routers

### DIFF
--- a/lib/ph/router.dart
+++ b/lib/ph/router.dart
@@ -7,7 +7,8 @@ import 'package:titan/drawer/class/module.dart';
 import 'package:titan/ph/providers/is_ph_admin_provider.dart';
 import 'package:titan/ph/ui/pages/form_page/add_edit_ph_page.dart'
     deferred as add_edit_ph_page;
-import 'package:titan/ph/ui/pages/past_ph_selection_page/past_ph_selection_page.dart';
+import 'package:titan/ph/ui/pages/past_ph_selection_page/past_ph_selection_page.dart'
+    deferred as past_ph_selection_page;
 import 'package:titan/tools/middlewares/admin_middleware.dart';
 import 'package:titan/tools/middlewares/deferred_middleware.dart';
 import 'package:qlevar_router/qlevar_router.dart';
@@ -40,7 +41,10 @@ class PhRouter {
     children: [
       QRoute(
         path: past_ph_selection,
-        builder: () => const PastPhSelectionPage(),
+        builder: () => past_ph_selection_page.PastPhSelectionPage(),
+        middleware: [
+          DeferredLoadingMiddleware(past_ph_selection_page.loadLibrary),
+        ],
         children: [
           QRoute(
             path: view_ph,

--- a/lib/purchases/router.dart
+++ b/lib/purchases/router.dart
@@ -3,15 +3,22 @@ import 'package:heroicons/heroicons.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:titan/drawer/class/module.dart';
 import 'package:titan/purchases/providers/purchases_admin_provider.dart';
-import 'package:titan/purchases/ui/pages/history_page/history_page.dart';
-import 'package:titan/purchases/ui/pages/main_page/main_page.dart';
-import 'package:titan/purchases/ui/pages/purchase_page/purchase_page.dart';
-import 'package:titan/purchases/ui/pages/scan_page/scan_page.dart';
-import 'package:titan/purchases/ui/pages/ticket_page/ticket_page.dart';
-import 'package:titan/purchases/ui/pages/user_list_page/user_list_page.dart';
+import 'package:titan/purchases/ui/pages/history_page/history_page.dart'
+    deferred as history_page;
+import 'package:titan/purchases/ui/pages/main_page/main_page.dart'
+    deferred as main_page;
+import 'package:titan/purchases/ui/pages/purchase_page/purchase_page.dart'
+    deferred as purchase_page;
+import 'package:titan/purchases/ui/pages/scan_page/scan_page.dart'
+    deferred as scan_page;
+import 'package:titan/purchases/ui/pages/ticket_page/ticket_page.dart'
+    deferred as ticket_page;
+import 'package:titan/purchases/ui/pages/user_list_page/user_list_page.dart'
+    deferred as user_list_page;
 import 'package:titan/tools/middlewares/admin_middleware.dart';
 import 'package:titan/tools/middlewares/authenticated_middleware.dart';
 import 'package:qlevar_router/qlevar_router.dart';
+import 'package:titan/tools/middlewares/deferred_middleware.dart';
 
 class PurchasesRouter {
   final Ref ref;
@@ -32,21 +39,45 @@ class PurchasesRouter {
   QRoute route() => QRoute(
     name: "purchases",
     path: PurchasesRouter.root,
-    builder: () => const PurchasesMainPage(),
-    middleware: [AuthenticatedMiddleware(ref)],
+    builder: () => main_page.PurchasesMainPage(),
+    middleware: [
+      AuthenticatedMiddleware(ref),
+      DeferredLoadingMiddleware(main_page.loadLibrary),
+    ],
     children: [
       QRoute(
         path: scan,
-        builder: () => const ScanPage(),
-        middleware: [AdminMiddleware(ref, isPurchasesAdminProvider)],
+        builder: () => scan_page.ScanPage(),
+        middleware: [
+          AdminMiddleware(ref, isPurchasesAdminProvider),
+          DeferredLoadingMiddleware(scan_page.loadLibrary),
+        ],
       ),
       QRoute(
         path: history,
-        builder: () => const HistoryPage(),
-        children: [QRoute(path: purchase, builder: () => const PurchasePage())],
+        builder: () => history_page.HistoryPage(),
+        middleware: [DeferredLoadingMiddleware(history_page.loadLibrary)],
+        children: [
+          QRoute(
+            path: purchase,
+            builder: () => purchase_page.PurchasePage(),
+            middleware: [DeferredLoadingMiddleware(purchase_page.loadLibrary)],
+          ),
+        ],
       ),
-      QRoute(path: ticket, builder: () => const TicketPage()),
-      QRoute(path: userList, builder: () => const UserListPage()),
+      QRoute(
+        path: ticket,
+        builder: () => ticket_page.TicketPage(),
+        middleware: [DeferredLoadingMiddleware(ticket_page.loadLibrary)],
+      ),
+      QRoute(
+        path: userList,
+        builder: () => user_list_page.UserListPage(),
+        middleware: [
+          AdminMiddleware(ref, isPurchasesAdminProvider),
+          DeferredLoadingMiddleware(user_list_page.loadLibrary),
+        ],
+      ),
     ],
   );
 }


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

We want to defer the loading of every page until it is actually visited (statistically, a given page is not visited).
A couple pages were still not deferred to this date.

<!--#### Sources at the end-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] purchases: deferred everything
- [x] ph: one page was forgotten
- [x] checked manually that there is no other missing case

<!--Don't touch these two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [x] Multiple modules changes
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [x] No documentation needed

</details>
