### PR TITLE
Flutter 3.41

### DIFF
--- a/lib/drawer/ui/drawer_template.dart
+++ b/lib/drawer/ui/drawer_template.dart
@@ -78,8 +78,8 @@ class DrawerTemplate extends HookConsumerWidget {
                     Transform(
                       alignment: Alignment.centerLeft,
                       transform: Matrix4.identity()
-                        ..translate(translateVal)
-                        ..scale(scaleVal),
+                        ..translateByDouble(translateVal, 0, 0, 1)
+                        ..scaleByDouble(scaleVal, scaleVal, scaleVal, 1),
                       child: GestureDetector(
                         onTap: () {
                           if (controller.isCompleted) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -937,18 +937,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1398,10 +1398,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timeago:
     dependency: "direct main"
     description:
@@ -1660,4 +1660,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.6 <4.0.0"
+  flutter: ">=3.41.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ minimal_hyperion_version: 5.0.2
 
 environment:
   sdk: ^3.10.0
-  flutter: ^3.38.6
+  flutter: ^3.41.2
 
 dependencies:
   app_links: ^6.4.0


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

[Flutter 3.41](https://docs.flutter.dev/release/release-notes/release-notes-3.41.0) is out there.

(I'm going to need it for the new dev flag to disable cross-origin isolation in WASM builds.)
Anyway, I chose to bump the version here in a dedicated PR instead
- for testing purposes (the app works just as before)
- so no-one complains the PR does too much at a time

<!--#### Sources at the end-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Fix two 3.38 deprecations
- [x] Bump Flutter version to 3.41.2 and get packages for new versions

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch these two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [x] Other: Version bump <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [x] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [x] No documentation needed

</details>
