### PR TITLE
Fix(workflows): don't run lint&format when editing a PR description

### DIFF
--- a/.github/workflows/lintandformat.yml
+++ b/.github/workflows/lintandformat.yml
@@ -3,7 +3,7 @@ name: Lint and format
 
 on:
   pull_request:
-    types: [opened, edited, ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize]
 
 jobs:
   lintandformat:


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

Just noticed that editing the description of #671 (which will happens a couple times) triggered `lintandformat`, and only it (the test workflows and others were already fixed somehow).

## Changes Made

One-line change

<!--Don't touch these two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [x] Other: workflows YAML <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [x] 0. Untestable but trust me

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [x] No documentation needed

</details>
