### PR TITLE
Dark theme: Centralassociation

### DIFF
--- a/lib/centralassociation/ui/centralassociation.dart
+++ b/lib/centralassociation/ui/centralassociation.dart
@@ -10,19 +10,16 @@ class CentralassociationTemplate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(
-        color: Colors.white,
-        child: SafeArea(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              const TopBar(
-                title: CentralassociationTextConstants.centralassociation,
-                root: CentralassociationRouter.root,
-              ),
-              Expanded(child: child),
-            ],
-          ),
+      body: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            const TopBar(
+              title: CentralassociationTextConstants.centralassociation,
+              root: CentralassociationRouter.root,
+            ),
+            Expanded(child: child),
+          ],
         ),
       ),
     );

--- a/lib/centralassociation/ui/pages/asso_list.dart
+++ b/lib/centralassociation/ui/pages/asso_list.dart
@@ -15,7 +15,7 @@ class AssoList extends StatelessWidget {
         children: [
           Text(
             asso.name,
-            style: const TextStyle(fontSize: 23, fontWeight: FontWeight.w900),
+            style: TextStyle(fontSize: 23, fontWeight: FontWeight.w900),
           ),
           const SizedBox(height: 10),
           Column(

--- a/lib/centralassociation/ui/pages/asso_list.dart
+++ b/lib/centralassociation/ui/pages/asso_list.dart
@@ -15,7 +15,7 @@ class AssoList extends StatelessWidget {
         children: [
           Text(
             asso.name,
-            style: TextStyle(fontSize: 23, fontWeight: FontWeight.w900),
+            style: const TextStyle(fontSize: 23, fontWeight: FontWeight.w900),
           ),
           const SizedBox(height: 10),
           Column(

--- a/lib/centralassociation/ui/pages/link_card.dart
+++ b/lib/centralassociation/ui/pages/link_card.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:titan/centralassociation/class/link.dart';
@@ -15,10 +16,10 @@ class LinkCard extends HookConsumerWidget {
       margin: const EdgeInsets.symmetric(vertical: 7),
       decoration: BoxDecoration(
         borderRadius: const BorderRadius.all(Radius.circular(20)),
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.primary,
         boxShadow: [
           BoxShadow(
-            color: Colors.grey.withValues(alpha: 0.3),
+            color: Theme.of(context).shadowColor,
             blurRadius: 8,
             spreadRadius: 2,
             offset: const Offset(2, 3),
@@ -31,9 +32,6 @@ class LinkCard extends HookConsumerWidget {
           shape: WidgetStateProperty.all<RoundedRectangleBorder>(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)),
           ),
-          overlayColor: WidgetStateProperty.all<Color>(
-            const Color.fromARGB(37, 0, 0, 0),
-          ),
         ),
         child: Row(
           children: [
@@ -41,6 +39,17 @@ class LinkCard extends HookConsumerWidget {
               margin: const EdgeInsets.only(left: 10.0, right: 10.0, bottom: 3),
               width: 45,
               height: 45,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                boxShadow: [
+                  BoxShadow(
+                    color: Theme.of(context).shadowColor,
+                    blurRadius: 5,
+                    spreadRadius: 2,
+                  ),
+                ],
+                borderRadius: BorderRadius.circular(15),
+              ),
               child: link.icon.endsWith('.svg')
                   ? SvgPicture.network(
                       "${CentralassociationTextConstants.imagePath}${link.icon}",
@@ -51,15 +60,19 @@ class LinkCard extends HookConsumerWidget {
             ),
             const SizedBox(width: 10),
             Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    link.name,
-                    style: const TextStyle(fontSize: 18, color: Colors.black),
+              child: Container(
+                alignment: Alignment.center,
+                padding: const EdgeInsets.only(bottom: 7),
+                child: AutoSizeText(
+                  link.name,
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Theme.of(context).colorScheme.onPrimary,
                   ),
-                ],
+                  minFontSize: 10,
+                  maxLines: 2,
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
           ],


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

See #671

<img width="1301" height="581" alt="image" src="https://github.com/user-attachments/assets/392e88cb-bae4-48e3-ad8f-b74ac7e42a41" />

## Required PRs

Depends on #671 

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

Dark mode on the Centrassociation module

- [x] centralassociation
  - [x] pages
    - [x] link_card
    - [x] main_page
    - [x] asso_list
  - [x] centralassociation

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch these two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [x] Single module changes
- [ ] Multiple modules changes
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a local client using a pre-prod backend
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `//` Comments
- [ ] No documentation needed

</details>
